### PR TITLE
Feature/manipulation plugin

### DIFF
--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -1,27 +1,27 @@
 axes:
   0: # Left joystick left/right
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "move_left_right"
+    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
+    function: "steer"
 
   1: # Left joystick up/down
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "move_up_down"
+    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
+    function: "drive"
 
   2: # LT
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "move_backward"
+    plugin: ""
+    function: ""
 
   3: # Right joystick left/right
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "rotate_yaw"
+    plugin: ""
+    function: ""
 
   4: # Right joystick up/down
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "rotate_pitch"
+    plugin: ""
+    function: ""
 
   5: # RT
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "move_forward"
+    plugin: ""
+    function: ""
 
   6: # Cross left/right
     plugin: ""
@@ -33,28 +33,28 @@ axes:
 
 buttons:
   0: # Button A
+    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
+    function: "fast"
+
+  1: # Button B
     plugin: ""
     function: ""
 
-  1: # Button B
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "hold_mode"
-
   2: # Button X
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "gripper_close"
+    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
+    function: "slow"
 
   3: # Button Y
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "gripper_open"
+    plugin: ""
+    function: ""
 
   4: # Button LB
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "rotate_roll_counter_clockwise"
+    plugin: ""
+    function: ""
 
   5: # Button RB
-    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
-    function: "rotate_roll_clockwise"
+    plugin: ""
+    function: ""
 
   6: # Button Back
     plugin: ""

--- a/hector_gamepad_manager/config/gamepad_mappings.yaml
+++ b/hector_gamepad_manager/config/gamepad_mappings.yaml
@@ -1,27 +1,27 @@
 axes:
   0: # Left joystick left/right
-    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
-    function: "steer"
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_left_right"
 
   1: # Left joystick up/down
-    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
-    function: "drive"
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_up_down"
 
   2: # LT
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_backward"
 
   3: # Right joystick left/right
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_yaw"
 
   4: # Right joystick up/down
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_pitch"
 
   5: # RT
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_forward"
 
   6: # Cross right/left
     plugin: ""
@@ -33,28 +33,28 @@ axes:
 
 buttons:
   0: # Button A
-    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
-    function: "fast"
+    plugin: ""
+    function: ""
 
   1: # Button B
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "hold_mode"
 
   2: # Button X
-    plugin: "hector_gamepad_manager_plugins::DrivePlugin"
-    function: "slow"
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "gripper_close"
 
   3: # Button Y
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "gripper_open"
 
   4: # Button LB
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_roll_counter_clockwise"
 
   5: # Button RB
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_roll_clockwise"
 
   6: # Button Back
     plugin: ""

--- a/hector_gamepad_manager/config/manipulation.yaml
+++ b/hector_gamepad_manager/config/manipulation.yaml
@@ -1,29 +1,29 @@
 axes:
   0: # Left joystick left/right
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_left_right"
 
   1: # Left joystick up/down
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_up_down"
 
   2: # LT
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_backward"
 
   3: # Right joystick left/right
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_yaw"
 
   4: # Right joystick up/down
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_pitch"
 
   5: # RT
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "move_forward"
 
-  6: # Cross left/right
+  6: # Cross right/left
     plugin: ""
     function: ""
 
@@ -34,27 +34,27 @@ axes:
 buttons:
   0: # Button A
     plugin: ""
-    function: "fast"
+    function: ""
 
   1: # Button B
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "hold_mode"
 
   2: # Button X
-    plugin: ""
-    function: "slow"
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "gripper_close"
 
   3: # Button Y
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "gripper_open"
 
   4: # Button LB
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_roll_counter_clockwise"
 
   5: # Button RB
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ManipulationPlugin"
+    function: "rotate_roll_clockwise"
 
   6: # Button Back
     plugin: ""
@@ -64,7 +64,7 @@ buttons:
     plugin: ""
     function: ""
 
-  8: # Button Guide (Manufacturer Button)
+  8: # Button Logitech
     plugin: ""
     function: ""
 
@@ -73,62 +73,5 @@ buttons:
     function: ""
 
   10: # Right joystick press
-    plugin: ""
-    function: ""
-
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
-    plugin: ""
-    function: ""
-
-  12: # Left joystick right
-    plugin: ""
-    function: ""
-
-  13: # Left joystick up
-    plugin: ""
-    function: ""
-
-  14: # Left joystick down
-    plugin: ""
-    function: ""
-
-  15: # LT
-    plugin: ""
-    function: ""
-
-  16: # Right joystick left
-    plugin: ""
-    function: ""
-
-  17: # Right joystick right
-    plugin: ""
-    function: ""
-
-  18: # Right joystick up
-    plugin: ""
-    function: ""
-
-  19: # Right joystick down
-    plugin: ""
-    function: ""
-
-  20: # RT
-    plugin: ""
-    function: ""
-
-  21: # Cross left
-    plugin: ""
-    function: ""
-
-  22: # Cross right
-    plugin: ""
-    function: ""
-
-  23: # Cross up
-    plugin: ""
-    function: ""
-
-  24: # Cross down
     plugin: ""
     function: ""

--- a/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
+++ b/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
@@ -2,10 +2,13 @@ launch:
 - arg:
     # Meta Config File that determines which buttons activate which config
     name: "config_name"
+    default: "athena"
 - arg:
     name: "robot_namespace"
+    default: "athena"
 - arg:
     name: "ocs_namespace"
+    default: "ocs"
 
 - node:
     pkg: "hector_gamepad_manager"

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(rclcpp REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(hector_gamepad_manager REQUIRED)
 
 set(HEADERS
@@ -25,6 +26,7 @@ set(HEADERS
 
 set(SOURCES
   src/drive_plugin.cpp
+  src/manipulation_plugin.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
@@ -33,7 +35,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>
     )
 
-ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp sensor_msgs geometry_msgs pluginlib hector_gamepad_manager)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp sensor_msgs geometry_msgs std_srvs pluginlib hector_gamepad_manager)
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
@@ -66,6 +68,6 @@ endif()
 
 ament_export_targets(${PROJECT_NAME}-targets)
 ament_export_include_directories(include)
-ament_export_dependencies(rclcpp sensor_msgs geometry_msgs pluginlib hector_gamepad_manager)
+ament_export_dependencies(rclcpp sensor_msgs geometry_msgs pluginlib std_srvs hector_gamepad_manager)
 
 ament_package()

--- a/hector_gamepad_manager_plugins/README.md
+++ b/hector_gamepad_manager_plugins/README.md
@@ -17,7 +17,7 @@ This plugin is used to drive the robot using a gamepad.
 ## Manipulation Plugin
 
 This plugin can be used to control the robots end-effector and gripper.
-Additionally, in the hold mode the robot can be driven while the end-effector remains at its hold position.
+Additionally, in the hold mode the robot can be driven while the end-effector remains at its current position in the world frame.
 
 ### Functions
 #### Axis
@@ -32,4 +32,4 @@ Additionally, in the hold mode the robot can be driven while the end-effector re
 - `rotate_roll_counterclockwise`: Rotate the end-effector counterclockwise around the roll axis.
 - `open_gripper`: Open the gripper.
 - `close_gripper`: Close the gripper.
-- `hold_mode`: Toggle the hold mode. In hold mode the robot can be driven while the end-effector remains at its hold position.
+- `hold_mode`: Toggle the hold mode. In hold mode the robot can be driven while the end-effector remains at its current position in the world frame.

--- a/hector_gamepad_manager_plugins/README.md
+++ b/hector_gamepad_manager_plugins/README.md
@@ -13,3 +13,23 @@ This plugin is used to drive the robot using a gamepad.
 - `steer`: Left and right steering of the robot.
 - `fast`: Fast driving mode
 - `slow`: Slow driving mode
+
+## Manipulation Plugin
+
+This plugin can be used to control the robots end-effector and gripper.
+Additionally, in the hold mode the robot can be driven while the end-effector remains at its hold position.
+
+### Functions
+#### Axis
+- `move_left_right`: Move the end-effector left and right. Or move the robot base while the hold button is pressed.
+- `move_up_down`: Move the end-effector up and down. Or move the robot base while the hold button is pressed.
+- `move_forward`: Move the end-effector forward. 
+- `move_backward`: Move the end-effector backward.
+- `rotate_pitch`: Rotate the end-effector around the pitch axis.
+- `rotate_yaw`: Rotate the end-effector around the yaw axis.
+#### Buttons
+- `rotate_roll_clockwise`: Rotate the end-effector clockwise around the roll axis.
+- `rotate_roll_counterclockwise`: Rotate the end-effector counterclockwise around the roll axis.
+- `open_gripper`: Open the gripper.
+- `close_gripper`: Close the gripper.
+- `hold_mode`: Toggle the hold mode. In hold mode the robot can be driven while the end-effector remains at its hold position.

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
@@ -11,12 +11,13 @@
 #include <std_srvs/srv/set_bool.hpp>
 namespace hector_gamepad_manager_plugins
 {
-class ManipulationPlugin : public hector_gamepad_manager::GamepadFunctionPlugin
+class ManipulationPlugin final : public hector_gamepad_manager::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node, const bool active ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
-  void handleButton( const std::string &function, const bool pressed ) override;
+  void handlePress(const std::string &function) override;
+  void handleRelease(const std::string &function) override;
 
   void handleAxis( const std::string &function, const double value ) override;
 
@@ -25,6 +26,13 @@ public:
   void activate() override;
 
   void deactivate() override;
+
+  /**
+   * Avoid repeatedly sending zero cmd_vel commands.
+   * @param linear_speed
+   * @param angular_speed
+   */
+  void sendDriveCommand( double linear_speed, double angular_speed );
 
   /**
    * Reset all motion commands to zero.
@@ -47,17 +55,18 @@ private:
 
   bool hold_mode_active_ = false;
   bool hold_mode_change_requested_ = false;
+  bool last_cmd_zero_ = false;
 
   double move_left_right_ = 0.0;
   double move_up_down_ = 0.0;
   double move_forward_ = 0.0;
   double move_backward_ = 0.0;
-  double rotate_pitch = 0.0;
-  double rotate_yaw = 0.0;
-  double rotate_roll_clockwise = 0.0;
-  double rotate_roll_counter_clockwise = 0.0;
-  double open_gripper = 0.0;
-  double close_gripper = 0.0;
+  double rotate_pitch_ = 0.0;
+  double rotate_yaw_ = 0.0;
+  double rotate_roll_clockwise_ = 0.0;
+  double rotate_roll_counter_clockwise_ = 0.0;
+  double open_gripper_ = 0.0;
+  double close_gripper_ = 0.0;
 
   geometry_msgs::msg::TwistStamped eef_cmd_;
   geometry_msgs::msg::TwistStamped drive_cmd_;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
@@ -1,0 +1,68 @@
+//
+// Created by aljoscha-schmidt on 2/14/25.
+//
+#ifndef HECTOR_GAMEPAD_MANAGER_PLUGINS_MANIPULATION_PLUGIN_HPP
+#define HECTOR_GAMEPAD_MANAGER_PLUGINS_MANIPULATION_PLUGIN_HPP
+
+#include <hector_gamepad_manager/gamepad_function_plugin.hpp>
+
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+namespace hector_gamepad_manager_plugins
+{
+class ManipulationPlugin : public hector_gamepad_manager::GamepadFunctionPlugin
+{
+public:
+  void initialize( const rclcpp::Node::SharedPtr &node, const bool active ) override;
+
+  void handleButton( const std::string &function, const bool pressed ) override;
+
+  void handleAxis( const std::string &function, const double value ) override;
+
+  void update() override;
+
+  void activate() override;
+
+  void deactivate() override;
+
+  /**
+   * Reset all motion commands to zero.
+   */
+  void reset();
+
+private:
+  rclcpp::Node::SharedPtr node_;
+
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr eef_cmd_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr drive_cmd_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr gripper_cmd_pub_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr hold_mode_client_;
+
+  double max_eef_linear_speed_ = 0.0;
+  double max_eef_angular_speed_ = 0.0;
+  double max_gripper_speed_ = 0.0;
+  double max_drive_linear_speed_ = 0.0;
+  double max_drive_angular_speed_ = 0.0;
+
+  bool hold_mode_active_ = false;
+  bool hold_mode_change_requested_ = false;
+
+  double move_left_right_ = 0.0;
+  double move_up_down_ = 0.0;
+  double move_forward_ = 0.0;
+  double move_backward_ = 0.0;
+  double rotate_pitch = 0.0;
+  double rotate_yaw = 0.0;
+  double rotate_roll_clockwise = 0.0;
+  double rotate_roll_counter_clockwise = 0.0;
+  double open_gripper = 0.0;
+  double close_gripper = 0.0;
+
+  geometry_msgs::msg::TwistStamped eef_cmd_;
+  geometry_msgs::msg::TwistStamped drive_cmd_;
+  std_msgs::msg::Float64 gripper_cmd_;
+};
+} // namespace hector_gamepad_manager_plugins
+
+#endif // HECTOR_GAMEPAD_MANAGER_PLUGINS_MANIPULATION_PLUGIN_HPP

--- a/hector_gamepad_manager_plugins/package.xml
+++ b/hector_gamepad_manager_plugins/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>pluginlib</depend>
   <depend>hector_gamepad_manager</depend>
 

--- a/hector_gamepad_manager_plugins/plugins.xml
+++ b/hector_gamepad_manager_plugins/plugins.xml
@@ -3,4 +3,7 @@
     <class type="hector_gamepad_manager_plugins::DrivePlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
         <description>Drive functionality plugin</description>
     </class>
+    <class type="hector_gamepad_manager_plugins::ManipulationPlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
+        <description>Manipulation functionality plugin</description>
+    </class>
 </library>

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -3,10 +3,9 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node, const bool active )
+void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node )
 {
   node_ = node;
-  active_ = active;
 
   plugin_namespace_ = "manipulation_plugin";
 
@@ -33,36 +32,43 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node, const 
   hold_mode_client_ = node_->create_client<std_srvs::srv::SetBool>( "teleop/hold_mode" );
 }
 
-void ManipulationPlugin::handleButton( const std::string &function, const bool pressed )
+void ManipulationPlugin::handlePress( const std::string &function )
 {
-  if ( !active_ ) {
-    return;
+  if ( function == "hold_mode" ) {
+    hold_mode_change_requested_ = true;
+    hold_mode_active_ = true;
   }
-
-  if ( function == "hold_mode" ) { // TODO wait for merge request -> handle on press and release
-    if ( hold_mode_active_ != pressed ) {
-      hold_mode_change_requested_ = true;
-    }
-    hold_mode_active_ = pressed;
-  } else if ( pressed ) { // TODO wait for merge request -> handle on press and release
-    if ( function == "rotate_roll_clockwise" ) {
-      rotate_roll_clockwise = max_eef_angular_speed_;
-    } else if ( function == "rotate_roll_counter_clockwise" ) {
-      rotate_roll_counter_clockwise = max_eef_angular_speed_;
-    } else if ( function == "gripper_open" ) {
-      gripper_cmd_.data = max_gripper_speed_;
-    } else if ( function == "gripper_close" ) {
-      gripper_cmd_.data = max_gripper_speed_;
-    }
+  else if ( function == "rotate_roll_clockwise" ) {
+    rotate_roll_clockwise_ = max_eef_angular_speed_;
+  } else if ( function == "rotate_roll_counter_clockwise" ) {
+    rotate_roll_counter_clockwise_ = -max_eef_angular_speed_;
+  } else if ( function == "gripper_open" ) {
+    open_gripper_ = max_gripper_speed_;
+  } else if ( function == "gripper_close" ) {
+    close_gripper_ = -max_gripper_speed_;
   }
 }
 
+void ManipulationPlugin::handleRelease( const std::string &function )
+{
+  if ( function == "hold_mode" ) {
+    hold_mode_change_requested_ = true;
+    hold_mode_active_ = false;
+  }
+  else if ( function == "rotate_roll_clockwise" ) {
+    rotate_roll_clockwise_ = 0.0;
+  } else if ( function == "rotate_roll_counter_clockwise" ) {
+    rotate_roll_counter_clockwise_ = 0.0;
+  } else if ( function == "gripper_open" ) {
+    open_gripper_ = 0.0;
+  } else if ( function == "gripper_close" ) {
+    close_gripper_ = 0.0;
+  }
+}
+
+
 void ManipulationPlugin::handleAxis( const std::string &function, const double value )
 {
-  if ( !active_ ) {
-    return;
-  }
-
   if ( function == "move_left_right" ) {
     move_left_right_ = value;
   } else if ( function == "move_up_down" ) {
@@ -70,11 +76,11 @@ void ManipulationPlugin::handleAxis( const std::string &function, const double v
   } else if ( function == "move_forward" ) {
     move_forward_ = value;
   } else if ( function == "move_backward" ) {
-    move_backward_ = value;
+    move_backward_ = -value;
   } else if ( function == "rotate_pitch" ) {
-    rotate_pitch = value;
+    rotate_pitch_ = value;
   } else if ( function == "rotate_yaw" ) {
-    rotate_yaw = value;
+    rotate_yaw_ = value;
   }
 }
 
@@ -91,26 +97,26 @@ void ManipulationPlugin::update()
     // reset cmds when hold mode is toggled
     reset();
   }
+  double cmd_vel_linear=0.0, cmd_vel_angular=0.0;
   if ( hold_mode_active_ ) {
     // left joystick moves base, ignore all other axis and buttons
-    drive_cmd_.twist.linear.x = move_up_down_ * max_drive_linear_speed_;
-    drive_cmd_.twist.angular.z = move_left_right_ * max_drive_angular_speed_;
+    cmd_vel_linear = move_up_down_ * max_drive_linear_speed_;
+    cmd_vel_angular = move_left_right_ * max_drive_angular_speed_;
   } else {
-    eef_cmd_.twist.linear.x = ( move_forward_ - move_backward_ ) * max_eef_linear_speed_;
+    eef_cmd_.twist.linear.x = ( move_forward_ + move_backward_ ) * max_eef_linear_speed_;
     eef_cmd_.twist.linear.y = move_left_right_ * max_eef_linear_speed_;
     eef_cmd_.twist.linear.z = move_up_down_ * max_eef_linear_speed_;
     eef_cmd_.twist.angular.x =
-        ( rotate_roll_clockwise - rotate_roll_counter_clockwise ) * max_eef_angular_speed_;
-    eef_cmd_.twist.angular.y = rotate_pitch * max_eef_angular_speed_;
-    eef_cmd_.twist.angular.z = rotate_yaw * max_eef_angular_speed_;
-    gripper_cmd_.data = ( open_gripper - close_gripper ) * max_gripper_speed_;
+        ( rotate_roll_clockwise_ + rotate_roll_counter_clockwise_ ) * max_eef_angular_speed_;
+    eef_cmd_.twist.angular.y = rotate_pitch_ * max_eef_angular_speed_;
+    eef_cmd_.twist.angular.z = rotate_yaw_ * max_eef_angular_speed_;
+    gripper_cmd_.data = ( open_gripper_ + close_gripper_ ) * max_gripper_speed_;
   }
 
   eef_cmd_.header.stamp = node_->now();
   eef_cmd_pub_->publish( eef_cmd_ );
   gripper_cmd_pub_->publish( gripper_cmd_ );
-  drive_cmd_.header.stamp = node_->now();
-  drive_cmd_pub_->publish( drive_cmd_ );
+  sendDriveCommand( cmd_vel_linear, cmd_vel_angular );
 }
 
 void ManipulationPlugin::activate() { active_ = true; }
@@ -123,8 +129,7 @@ void ManipulationPlugin::deactivate()
   eef_cmd_.header.stamp = node_->now();
   eef_cmd_pub_->publish( eef_cmd_ );
   gripper_cmd_pub_->publish( gripper_cmd_ );
-  drive_cmd_.header.stamp = node_->now();
-  drive_cmd_pub_->publish( drive_cmd_ );
+  sendDriveCommand( 0,0 );
   // make sure hold mode is disabled when the plugin is deactivated
   if ( hold_mode_active_ ) {
     const auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
@@ -139,17 +144,31 @@ void ManipulationPlugin::reset()
   move_up_down_ = 0.0;
   move_forward_ = 0.0;
   move_backward_ = 0.0;
-  rotate_pitch = 0.0;
-  rotate_yaw = 0.0;
-  rotate_roll_clockwise = 0.0;
-  rotate_roll_counter_clockwise = 0.0;
-  open_gripper = 0.0;
-  close_gripper = 0.0;
+  rotate_pitch_ = 0.0;
+  rotate_yaw_ = 0.0;
+  rotate_roll_clockwise_ = 0.0;
+  rotate_roll_counter_clockwise_ = 0.0;
+  open_gripper_ = 0.0;
+  close_gripper_ = 0.0;
   eef_cmd_.twist = geometry_msgs::msg::Twist();
   drive_cmd_.twist = geometry_msgs::msg::Twist();
   gripper_cmd_.data = 0.0;
   hold_mode_change_requested_ = false;
 }
+
+void ManipulationPlugin::sendDriveCommand( const double linear_speed, const double angular_speed )
+{
+  drive_cmd_.header.stamp = node_->now();
+  drive_cmd_.twist.linear.x = linear_speed;
+  drive_cmd_.twist.angular.z = angular_speed;
+  const bool current_cmd_zero =
+      drive_cmd_.twist.linear.x == 0.0 && drive_cmd_.twist.angular.z == 0.0;
+  if ( !( current_cmd_zero && last_cmd_zero_ ) ) {
+    drive_cmd_pub_->publish( drive_cmd_ );
+  }
+  last_cmd_zero_ = current_cmd_zero;
+}
+
 } // namespace hector_gamepad_manager_plugins
 
 #include <pluginlib/class_list_macros.hpp>

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -1,0 +1,158 @@
+#include "hector_gamepad_manager_plugins/manipulation_plugin.hpp"
+
+namespace hector_gamepad_manager_plugins
+{
+
+void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node, const bool active )
+{
+  node_ = node;
+  active_ = active;
+
+  plugin_namespace_ = "manipulation_plugin";
+
+  node_->declare_parameters<double>( plugin_namespace_, { { "max_eef_linear_speed", 1.0 },
+                                                          { "max_eef_angular_speed", 1.0 },
+                                                          { "max_drive_linear_speed", 1.0 },
+                                                          { "max_drive_angular_speed", 1.0 },
+                                                          { "max_gripper_speed", 1.0 } } );
+
+  max_eef_linear_speed_ =
+      node_->get_parameter( plugin_namespace_ + ".max_eef_linear_speed" ).as_double();
+
+  max_eef_angular_speed_ =
+      node_->get_parameter( plugin_namespace_ + ".max_eef_angular_speed" ).as_double();
+  max_drive_linear_speed_ =
+      node_->get_parameter( plugin_namespace_ + ".max_drive_linear_speed" ).as_double();
+  max_drive_angular_speed_ =
+      node_->get_parameter( plugin_namespace_ + ".max_drive_angular_speed" ).as_double();
+  max_gripper_speed_ = node_->get_parameter( plugin_namespace_ + ".max_gripper_speed" ).as_double();
+
+  eef_cmd_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>( "teleop/eef_cmd", 10 );
+  drive_cmd_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>( "cmd_vel", 10 );
+  gripper_cmd_pub_ = node_->create_publisher<std_msgs::msg::Float64>( "teleop/gripper_cmd", 10 );
+  hold_mode_client_ = node_->create_client<std_srvs::srv::SetBool>( "teleop/hold_mode" );
+}
+
+void ManipulationPlugin::handleButton( const std::string &function, const bool pressed )
+{
+  if ( !active_ ) {
+    return;
+  }
+
+  if ( function == "hold_mode" ) { // TODO wait for merge request -> handle on press and release
+    if ( hold_mode_active_ != pressed ) {
+      hold_mode_change_requested_ = true;
+    }
+    hold_mode_active_ = pressed;
+  } else if ( pressed ) { // TODO wait for merge request -> handle on press and release
+    if ( function == "rotate_roll_clockwise" ) {
+      rotate_roll_clockwise = max_eef_angular_speed_;
+    } else if ( function == "rotate_roll_counter_clockwise" ) {
+      rotate_roll_counter_clockwise = max_eef_angular_speed_;
+    } else if ( function == "gripper_open" ) {
+      gripper_cmd_.data = max_gripper_speed_;
+    } else if ( function == "gripper_close" ) {
+      gripper_cmd_.data = max_gripper_speed_;
+    }
+  }
+}
+
+void ManipulationPlugin::handleAxis( const std::string &function, const double value )
+{
+  if ( !active_ ) {
+    return;
+  }
+
+  if ( function == "move_left_right" ) {
+    move_left_right_ = value;
+  } else if ( function == "move_up_down" ) {
+    move_up_down_ = value;
+  } else if ( function == "move_forward" ) {
+    move_forward_ = value;
+  } else if ( function == "move_backward" ) {
+    move_backward_ = value;
+  } else if ( function == "rotate_pitch" ) {
+    rotate_pitch = value;
+  } else if ( function == "rotate_yaw" ) {
+    rotate_yaw = value;
+  }
+}
+
+void ManipulationPlugin::update()
+{
+  if ( !active_ ) {
+    return;
+  }
+
+  if ( hold_mode_change_requested_ ) {
+    const auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
+    request->data = hold_mode_active_;
+    hold_mode_client_->async_send_request( request );
+    // reset cmds when hold mode is toggled
+    reset();
+  }
+  if ( hold_mode_active_ ) {
+    // left joystick moves base, ignore all other axis and buttons
+    drive_cmd_.twist.linear.x = move_up_down_ * max_drive_linear_speed_;
+    drive_cmd_.twist.angular.z = move_left_right_ * max_drive_angular_speed_;
+  } else {
+    eef_cmd_.twist.linear.x = ( move_forward_ - move_backward_ ) * max_eef_linear_speed_;
+    eef_cmd_.twist.linear.y = move_left_right_ * max_eef_linear_speed_;
+    eef_cmd_.twist.linear.z = move_up_down_ * max_eef_linear_speed_;
+    eef_cmd_.twist.angular.x =
+        ( rotate_roll_clockwise - rotate_roll_counter_clockwise ) * max_eef_angular_speed_;
+    eef_cmd_.twist.angular.y = rotate_pitch * max_eef_angular_speed_;
+    eef_cmd_.twist.angular.z = rotate_yaw * max_eef_angular_speed_;
+    gripper_cmd_.data = ( open_gripper - close_gripper ) * max_gripper_speed_;
+  }
+
+  eef_cmd_.header.stamp = node_->now();
+  eef_cmd_pub_->publish( eef_cmd_ );
+  gripper_cmd_pub_->publish( gripper_cmd_ );
+  drive_cmd_.header.stamp = node_->now();
+  drive_cmd_pub_->publish( drive_cmd_ );
+}
+
+void ManipulationPlugin::activate() { active_ = true; }
+
+void ManipulationPlugin::deactivate()
+{
+  active_ = false;
+
+  reset();
+  eef_cmd_.header.stamp = node_->now();
+  eef_cmd_pub_->publish( eef_cmd_ );
+  gripper_cmd_pub_->publish( gripper_cmd_ );
+  drive_cmd_.header.stamp = node_->now();
+  drive_cmd_pub_->publish( drive_cmd_ );
+  // make sure hold mode is disabled when the plugin is deactivated
+  if ( hold_mode_active_ ) {
+    const auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
+    request->data = false;
+    hold_mode_client_->async_send_request( request );
+  }
+}
+
+void ManipulationPlugin::reset()
+{
+  move_left_right_ = 0.0;
+  move_up_down_ = 0.0;
+  move_forward_ = 0.0;
+  move_backward_ = 0.0;
+  rotate_pitch = 0.0;
+  rotate_yaw = 0.0;
+  rotate_roll_clockwise = 0.0;
+  rotate_roll_counter_clockwise = 0.0;
+  open_gripper = 0.0;
+  close_gripper = 0.0;
+  eef_cmd_.twist = geometry_msgs::msg::Twist();
+  drive_cmd_.twist = geometry_msgs::msg::Twist();
+  gripper_cmd_.data = 0.0;
+  hold_mode_change_requested_ = false;
+}
+} // namespace hector_gamepad_manager_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS( hector_gamepad_manager_plugins::ManipulationPlugin,
+                        hector_gamepad_manager::GamepadFunctionPlugin )


### PR DESCRIPTION
This plugin can be used to control the robot's end-effector and gripper. The plugin sends TwistStamped for the end effector and robot base as well as Float64 commands for the gripper velocity. 
In the `hold` mode, the robot can be driven while the end-effector remains in its current position in the world frame.
