### PR TITLE
Feature/flipper control plugin

### DIFF
--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -1,0 +1,15 @@
+/**:
+    ros__parameters:
+        drive_plugin:
+            normal_factor: 0.6
+            slow_factor: 0.3
+            fast_factor: 1.0
+            max_angular_speed: 1.5
+            max_linear_speed: 1.0
+        flipper_plugin:
+            flipper_back_factor: 1.0
+            flipper_front_factor: 1.0
+            speed: 1.5  # max of dynamixel motors
+            standard_controller: "flipper_trajectory_controller"
+            teleop_controller: "flipper_velocity_controller"
+

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -7,7 +7,7 @@ axes:
     plugin: "hector_gamepad_manager_plugins::DrivePlugin"
     function: "drive"
 
-  2: # LB
+  2: # LT
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_back_down"
 
@@ -19,7 +19,7 @@ axes:
     plugin: ""
     function: ""
 
-  5: # RB
+  5: # RT
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_front_down"
 
@@ -48,11 +48,11 @@ buttons:
     plugin: ""
     function: ""
 
-  4: # Button LT
+  4: # Button LB
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_back_up"
 
-  5: # Button RT
+  5: # Button RB
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_front_up"
 

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -7,7 +7,7 @@ axes:
     plugin: "hector_gamepad_manager_plugins::DrivePlugin"
     function: "drive"
 
-  2: # LT
+  2: # LB
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_back_down"
 
@@ -19,7 +19,7 @@ axes:
     plugin: ""
     function: ""
 
-  5: # RT
+  5: # RB
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_front_down"
 
@@ -48,11 +48,11 @@ buttons:
     plugin: ""
     function: ""
 
-  4: # Button LB
+  4: # Button LT
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_back_up"
 
-  5: # Button RB
+  5: # Button RT
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     function: "flipper_front_up"
 

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -8,8 +8,8 @@ axes:
     function: "drive"
 
   2: # LT
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
+    function: "flipper_back_down"
 
   3: # Right joystick left/right
     plugin: ""
@@ -20,8 +20,8 @@ axes:
     function: ""
 
   5: # RT
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
+    function: "flipper_front_down"
 
   6: # Cross left/right
     plugin: ""
@@ -49,12 +49,12 @@ buttons:
     function: ""
 
   4: # Button LB
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
+    function: "flipper_back_up"
 
   5: # Button RB
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
+    function: "flipper_front_up"
 
   6: # Button Back
     plugin: ""

--- a/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_function_plugin.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_function_plugin.hpp
@@ -19,6 +19,12 @@ public:
   virtual void initialize( const rclcpp::Node::SharedPtr &node ) = 0;
 
   /**
+   * @brief Returns name of associated plugin
+   *
+   */
+  virtual std::string getPluginName()=0;
+
+  /**
    * @brief Handle button input events.
    *
    * @param function The function name that is associated with the button.
@@ -102,9 +108,6 @@ public:
 protected:
   // The ROS node
   rclcpp::Node::SharedPtr node_;
-
-  // The namespace of the plugin.
-  std::string plugin_namespace_;
 
   // Specifies if the plugin is active.
   bool active_ = false;

--- a/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
+++ b/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
@@ -19,3 +19,4 @@ launch:
         value: "$(var robot_namespace)"
       - name: "ocs_namespace"
         value: "$(var ocs_namespace)"
+      - from: "$(find-pkg-share hector_gamepad_manager)/config/$(var config_name)_plugin_config.yaml"

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -198,7 +198,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &button_mapping : configs_[config_name].button_mappings ) {
     if ( !button_mapping.second.plugin->isActive() ) {
       button_mapping.second.plugin->activate();
-      RCLCPP_INFO(ocs_ns_node_->get_logger(), "Activated plugin %s", button_mapping.second.plugin->getPluginName().c_str());
+      RCLCPP_INFO(ocs_ns_node_->get_logger(), "Activated plugin: %s", button_mapping.second.plugin->getPluginName().c_str());
       active_plugins_.push_back( button_mapping.second.plugin );
     }
   }
@@ -206,7 +206,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &axis_mapping : configs_[config_name].axis_mappings ) {
     if ( !axis_mapping.second.plugin->isActive() ) {
       axis_mapping.second.plugin->activate();
-      RCLCPP_INFO(ocs_ns_node_->get_logger(), "Activated plugin %s", axis_mapping.second.plugin->getPluginName().c_str());
+      RCLCPP_INFO(ocs_ns_node_->get_logger(), "Activated plugin: %s", axis_mapping.second.plugin->getPluginName().c_str());
       active_plugins_.push_back( axis_mapping.second.plugin );
     }
   }

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -29,8 +29,11 @@ HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node 
   // load meta switch config and all referenced config files
   if ( loadConfigSwitchesConfig( config_switches_filename ) ) {
     switchConfig( default_config_ );
+
+    rclcpp::SubscriptionOptions options;
+    options.callback_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     joy_subscription_ = ocs_ns_node_->create_subscription<sensor_msgs::msg::Joy>(
-        "joy", 1, std::bind( &HectorGamepadManager::joyCallback, this, std::placeholders::_1 ) );
+        "joy", 1, std::bind( &HectorGamepadManager::joyCallback, this, std::placeholders::_1 ), options);
   }
 }
 
@@ -227,10 +230,10 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   // Axes
   inputs.axes[0] = msg->axes[0];                    // Left joystick left/right
   inputs.axes[1] = msg->axes[1];                    // Left joystick up/down
-  inputs.axes[2] = -0.5f * ( msg->axes[2] - 1.0f ); // LB: Change range from [1, -1] to [0, 1]
+  inputs.axes[2] = -0.5f * ( msg->axes[2] - 1.0f ); // LT: Change range from [1, -1] to [0, 1]
   inputs.axes[3] = msg->axes[3];                    // Right joystick left/right
   inputs.axes[4] = msg->axes[4];                    // Right joystick up/down
-  inputs.axes[5] = -0.5f * ( msg->axes[5] - 1.0f ); // RB: Change range from [1, -1] to [0, 1]
+  inputs.axes[5] = -0.5f * ( msg->axes[5] - 1.0f ); // RT: Change range from [1, -1] to [0, 1]
   inputs.axes[6] = msg->axes[6];                    // Cross left/right
   inputs.axes[7] = msg->axes[7];                    // Cross up/down
 
@@ -239,8 +242,8 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   inputs.buttons[1] = msg->buttons[1];   // Button B
   inputs.buttons[2] = msg->buttons[2];   // Button X
   inputs.buttons[3] = msg->buttons[3];   // Button Y
-  inputs.buttons[4] = msg->buttons[4];   // Button LT
-  inputs.buttons[5] = msg->buttons[5];   // Button RT
+  inputs.buttons[4] = msg->buttons[4];   // Button LB
+  inputs.buttons[5] = msg->buttons[5];   // Button RB
   inputs.buttons[6] = msg->buttons[6];   // Button Back
   inputs.buttons[7] = msg->buttons[7];   // Button Start
   inputs.buttons[8] = msg->buttons[8];   // Button Guide -> Reserved for config switches
@@ -250,12 +253,12 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   inputs.buttons[12] = inputs.axes[0] < -AXIS_DEADZONE; // Left joystick right
   inputs.buttons[13] = inputs.axes[1] > AXIS_DEADZONE;  // Left joystick up
   inputs.buttons[14] = inputs.axes[1] < -AXIS_DEADZONE; // Left joystick down
-  inputs.buttons[15] = inputs.axes[2] > AXIS_DEADZONE;  // LB button
+  inputs.buttons[15] = inputs.axes[2] > AXIS_DEADZONE;  // LT button
   inputs.buttons[16] = inputs.axes[3] > AXIS_DEADZONE;  // Right joystick left
   inputs.buttons[17] = inputs.axes[3] < -AXIS_DEADZONE; // Right joystick right
   inputs.buttons[18] = inputs.axes[4] > AXIS_DEADZONE;  // Right joystick up
   inputs.buttons[19] = inputs.axes[4] < -AXIS_DEADZONE; // Right joystick down
-  inputs.buttons[20] = inputs.axes[5] > AXIS_DEADZONE;  // RB button
+  inputs.buttons[20] = inputs.axes[5] > AXIS_DEADZONE;  // RT button
   inputs.buttons[21] = inputs.axes[6] == 1.0f;          // Cross left
   inputs.buttons[22] = inputs.axes[6] == -1.0f;         // Cross right
   inputs.buttons[23] = inputs.axes[7] == 1.0f;          // Cross up

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -195,6 +195,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &button_mapping : configs_[config_name].button_mappings ) {
     if ( !button_mapping.second.plugin->isActive() ) {
       button_mapping.second.plugin->activate();
+      RCLCPP_INFO(ocs_ns_node_->get_logger(), "Activated plugin %s", button_mapping.second.plugin->getPluginName().c_str());
       active_plugins_.push_back( button_mapping.second.plugin );
     }
   }
@@ -202,6 +203,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &axis_mapping : configs_[config_name].axis_mappings ) {
     if ( !axis_mapping.second.plugin->isActive() ) {
       axis_mapping.second.plugin->activate();
+      RCLCPP_INFO(ocs_ns_node_->get_logger(), "Activated plugin %s", axis_mapping.second.plugin->getPluginName().c_str());
       active_plugins_.push_back( axis_mapping.second.plugin );
     }
   }

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -225,10 +225,10 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   // Axes
   inputs.axes[0] = msg->axes[0];                    // Left joystick left/right
   inputs.axes[1] = msg->axes[1];                    // Left joystick up/down
-  inputs.axes[2] = -0.5f * ( msg->axes[2] - 1.0f ); // LT: Change range from [1, -1] to [0, 1]
+  inputs.axes[2] = -0.5f * ( msg->axes[2] - 1.0f ); // LB: Change range from [1, -1] to [0, 1]
   inputs.axes[3] = msg->axes[3];                    // Right joystick left/right
   inputs.axes[4] = msg->axes[4];                    // Right joystick up/down
-  inputs.axes[5] = -0.5f * ( msg->axes[5] - 1.0f ); // RT: Change range from [1, -1] to [0, 1]
+  inputs.axes[5] = -0.5f * ( msg->axes[5] - 1.0f ); // RB: Change range from [1, -1] to [0, 1]
   inputs.axes[6] = msg->axes[6];                    // Cross left/right
   inputs.axes[7] = msg->axes[7];                    // Cross up/down
 
@@ -237,8 +237,8 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   inputs.buttons[1] = msg->buttons[1];   // Button B
   inputs.buttons[2] = msg->buttons[2];   // Button X
   inputs.buttons[3] = msg->buttons[3];   // Button Y
-  inputs.buttons[4] = msg->buttons[4];   // Button LB
-  inputs.buttons[5] = msg->buttons[5];   // Button RB
+  inputs.buttons[4] = msg->buttons[4];   // Button LT
+  inputs.buttons[5] = msg->buttons[5];   // Button RT
   inputs.buttons[6] = msg->buttons[6];   // Button Back
   inputs.buttons[7] = msg->buttons[7];   // Button Start
   inputs.buttons[8] = msg->buttons[8];   // Button Guide -> Reserved for config switches
@@ -248,12 +248,12 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   inputs.buttons[12] = inputs.axes[0] < -AXIS_DEADZONE; // Left joystick right
   inputs.buttons[13] = inputs.axes[1] > AXIS_DEADZONE;  // Left joystick up
   inputs.buttons[14] = inputs.axes[1] < -AXIS_DEADZONE; // Left joystick down
-  inputs.buttons[15] = inputs.axes[2] > AXIS_DEADZONE;  // LT button
+  inputs.buttons[15] = inputs.axes[2] > AXIS_DEADZONE;  // LB button
   inputs.buttons[16] = inputs.axes[3] > AXIS_DEADZONE;  // Right joystick left
   inputs.buttons[17] = inputs.axes[3] < -AXIS_DEADZONE; // Right joystick right
   inputs.buttons[18] = inputs.axes[4] > AXIS_DEADZONE;  // Right joystick up
   inputs.buttons[19] = inputs.axes[4] < -AXIS_DEADZONE; // Right joystick down
-  inputs.buttons[20] = inputs.axes[5] > AXIS_DEADZONE;  // RT button
+  inputs.buttons[20] = inputs.axes[5] > AXIS_DEADZONE;  // RB button
   inputs.buttons[21] = inputs.axes[6] == 1.0f;          // Cross left
   inputs.buttons[22] = inputs.axes[6] == -1.0f;         // Cross right
   inputs.buttons[23] = inputs.axes[7] == 1.0f;          // Cross up

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -30,10 +30,8 @@ HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node 
   if ( loadConfigSwitchesConfig( config_switches_filename ) ) {
     switchConfig( default_config_ );
 
-    rclcpp::SubscriptionOptions options;
-    options.callback_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     joy_subscription_ = ocs_ns_node_->create_subscription<sensor_msgs::msg::Joy>(
-        "joy", 1, std::bind( &HectorGamepadManager::joyCallback, this, std::placeholders::_1 ), options);
+        "joy", 1, std::bind( &HectorGamepadManager::joyCallback, this, std::placeholders::_1 ));
   }
 }
 

--- a/hector_gamepad_manager/src/hector_gamepad_manager_node.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager_node.cpp
@@ -6,7 +6,7 @@ int main( int argc, char **argv )
 {
   rclcpp::init( argc, argv );
   const auto node = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_node" );
-  rclcpp::executors::MultiThreadedExecutor exe;
+  rclcpp::executors::SingleThreadedExecutor exe;
   auto hector_gamepad_manager =
       std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node );
   exe.add_node(node);

--- a/hector_gamepad_manager/src/hector_gamepad_manager_node.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager_node.cpp
@@ -6,9 +6,11 @@ int main( int argc, char **argv )
 {
   rclcpp::init( argc, argv );
   const auto node = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_node" );
+  rclcpp::executors::MultiThreadedExecutor exe;
   auto hector_gamepad_manager =
       std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node );
-  rclcpp::spin( node );
+  exe.add_node(node);
+  exe.spin();
   rclcpp::shutdown();
   return 0;
 }

--- a/hector_gamepad_manager/src/hector_gamepad_manager_node.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager_node.cpp
@@ -6,11 +6,9 @@ int main( int argc, char **argv )
 {
   rclcpp::init( argc, argv );
   const auto node = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_node" );
-  rclcpp::executors::SingleThreadedExecutor exe;
   auto hector_gamepad_manager =
       std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node );
-  exe.add_node(node);
-  exe.spin();
+  rclcpp::spin( node );
   rclcpp::shutdown();
   return 0;
 }

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -21,10 +21,15 @@ find_package(hector_gamepad_manager REQUIRED)
 
 set(HEADERS
   include/hector_gamepad_manager_plugins/drive_plugin.hpp
+  include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+  include/hector_gamepad_manager_plugins/controller_helper.hpp
+
 )
 
 set(SOURCES
   src/drive_plugin.cpp
+  src/flipper_plugin.cpp
+  src/controller_helper.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(hector_gamepad_manager REQUIRED)
+find_package(controller_manager_msgs REQUIRED)
 
 set(HEADERS
   include/hector_gamepad_manager_plugins/drive_plugin.hpp
@@ -38,7 +39,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>
     )
 
-ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp sensor_msgs geometry_msgs pluginlib hector_gamepad_manager)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp controller_manager_msgs sensor_msgs geometry_msgs pluginlib hector_gamepad_manager)
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -1,44 +1,43 @@
 #ifndef HECTOR_GAMEPAD_MANAGER_PLUGINS_CONTROLLER_HELPER_HPP
 #define HECTOR_GAMEPAD_MANAGER_PLUGINS_CONTROLLER_HELPER_HPP
 
-#include <rclcpp/rclcpp.hpp>
 #include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
-
+#include <rclcpp/rclcpp.hpp>
 
 namespace hector_gamepad_manager_plugins
 {
-    class ControllerHelper{
+class ControllerHelper
+{
 
-        public:
+public:
+  ControllerHelper() = default;
+  ~ControllerHelper() = default;
 
-            ControllerHelper()=default;
-            ~ControllerHelper()=default;
+  void initialize( const rclcpp::Node::SharedPtr &node, std::string plugin_name );
 
-            void initialize(const rclcpp::Node::SharedPtr &node, std::string plugin_name);
+  void switchControllers( std::vector<std::string> start_controllers,
+                          std::vector<std::string> stop_controllers );
 
-            void switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
+private:
+  rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_client_;
+  rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr list_controllers_client_;
 
-        private:
+  void controller_list_cb(
+      rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response,
+      std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers );
+  void switch_controller_cb(
+      rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response );
 
-            rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_client_;
-            rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr list_controllers_client_;
+  rclcpp::Node::SharedPtr node_;
 
-            void controller_list_cb(rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response, std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
-            void switch_controller_cb(rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response);
+  int max_switch_tries_;
+  int max_wait_on_srv_tries_;
 
-            rclcpp::Node::SharedPtr node_;
+  int regular_srv_timeout_;     // nanoseconds
 
-            int max_switch_tries_;
-            int max_wait_on_srv_tries_;
+  std::string plugin_name_;
+};
+} // namespace hector_gamepad_manager_plugins
 
-            int switch_retry_sleep_rate_;   // hz
-            int regular_srv_timeout_;       // nanoseconds
-            int init_srv_timeout_;          // nanoseconds
-
-            std::string plugin_name_;  
-     
-    };
-}
-
-#endif 
+#endif

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -23,10 +23,10 @@ private:
   rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_client_;
   rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr list_controllers_client_;
 
-  void controller_list_cb(
+  void controllerListCb(
       rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response,
       std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers );
-  void switch_controller_cb(
+  void switchControllerCb(
       rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response );
 
   rclcpp::Node::SharedPtr node_;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -2,6 +2,9 @@
 #define HECTOR_GAMEPAD_MANAGER_PLUGINS_CONTROLLER_HELPER_HPP
 
 #include <rclcpp/rclcpp.hpp>
+#include "controller_manager_msgs/srv/list_controllers.hpp"
+#include "controller_manager_msgs/srv/switch_controller.hpp"
+
 
 namespace hector_gamepad_manager_plugins
 {
@@ -9,23 +12,27 @@ namespace hector_gamepad_manager_plugins
 
         public:
 
-            ControllerHelper(const rclcpp::Node::SharedPtr &node);
+            ControllerHelper()=default;
+            ~ControllerHelper()=default;
 
-            ~ControllerHelper();
 
-            void switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
+            void initialize(const rclcpp::Node::SharedPtr &node, std::string plugin_name);
+
+            bool switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
 
         private:
 
+            rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_client_;
+            rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr list_controllers_client_;
 
-            rclcpp::Client<controller_manager_msgs::srv::SwitchController> switch_controller_client_;
-
-            rclcpp::Client<controller_manager_msgs::srv::ListControllers> list_controllers_client_;
+            rclcpp::Node::SharedPtr node_;
 
             int max_switch_tries_;
+            int max_wait_on_srv_tries_;
+            int switch_sleep_rate_;
 
-            rclcpp::Node::SharedPtr& node_;
-    }
-
-
+            std::string plugin_name_;            
+    };
 }
+
+#endif 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -17,12 +17,15 @@ namespace hector_gamepad_manager_plugins
 
             void initialize(const rclcpp::Node::SharedPtr &node, std::string plugin_name);
 
-            bool switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
+            void switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
 
         private:
 
             rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_client_;
             rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr list_controllers_client_;
+
+            void controller_list_cb(rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response, std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
+            void switch_controller_cb(rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response);
 
             rclcpp::Node::SharedPtr node_;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -1,0 +1,31 @@
+#ifndef HECTOR_GAMEPAD_MANAGER_PLUGINS_CONTROLLER_HELPER_HPP
+#define HECTOR_GAMEPAD_MANAGER_PLUGINS_CONTROLLER_HELPER_HPP
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace hector_gamepad_manager_plugins
+{
+    class ControllerHelper{
+
+        public:
+
+            ControllerHelper(const rclcpp::Node::SharedPtr &node);
+
+            ~ControllerHelper();
+
+            void switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
+
+        private:
+
+
+            rclcpp::Client<controller_manager_msgs::srv::SwitchController> switch_controller_client_;
+
+            rclcpp::Client<controller_manager_msgs::srv::ListControllers> list_controllers_client_;
+
+            int max_switch_tries_;
+
+            rclcpp::Node::SharedPtr& node_;
+    }
+
+
+}

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -15,7 +15,6 @@ namespace hector_gamepad_manager_plugins
             ControllerHelper()=default;
             ~ControllerHelper()=default;
 
-
             void initialize(const rclcpp::Node::SharedPtr &node, std::string plugin_name);
 
             bool switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers);
@@ -29,9 +28,13 @@ namespace hector_gamepad_manager_plugins
 
             int max_switch_tries_;
             int max_wait_on_srv_tries_;
-            int switch_sleep_rate_;
 
-            std::string plugin_name_;            
+            int switch_retry_sleep_rate_;   // hz
+            int regular_srv_timeout_;       // nanoseconds
+            int init_srv_timeout_;          // nanoseconds
+
+            std::string plugin_name_;  
+     
     };
 }
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/controller_helper.hpp
@@ -31,9 +31,6 @@ private:
 
   rclcpp::Node::SharedPtr node_;
 
-  int max_switch_tries_;
-  int max_wait_on_srv_tries_;
-
   int regular_srv_timeout_;     // nanoseconds
 
   std::string plugin_name_;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
@@ -13,6 +13,8 @@ public:
 
   void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
+  std::string getPluginName() override;
+
   void handleAxis( const std::string &function, double value ) override;
 
   void handlePress( const std::string &function ) override;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -4,15 +4,18 @@
 #include <hector_gamepad_manager/gamepad_function_plugin.hpp>
 
 #include "std_msgs/msg/float64_multi_array.hpp"
+#include "hector_gamepad_manager_plugins/controller_helper.hpp"
 
 namespace hector_gamepad_manager_plugins
 {
 class FlipperPlugin : public hector_gamepad_manager::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node, const bool active ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node) override;
 
-  void handleButton( const std::string &function, const bool pressed ) override;
+  void handlePress( const std::string &function ) override;
+
+  void handleHold( const std::string &function ) override;
 
   void handleAxis( const std::string &function, const double value ) override;
 
@@ -30,6 +33,11 @@ private:
   double speed_;
   double flipper_front_factor_;
   double flipper_back_factor_;
+
+  std::string standard_controller_;
+  std::string teleop_controller_;
+
+  ControllerHelper controller_helper_;
 
   std_msgs::msg::Float64MultiArray flipper_speed_commands_;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -13,6 +13,8 @@ class FlipperPlugin : public hector_gamepad_manager::GamepadFunctionPlugin
 public:
   void initialize( const rclcpp::Node::SharedPtr &node) override;
 
+  std::string getPluginName() override;
+
   void handlePress( const std::string &function ) override;
 
   void handleHold( const std::string &function ) override;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -44,6 +44,7 @@ private:
   std_msgs::msg::Float64MultiArray flipper_speed_commands_;
 
   std::vector<double> vel_commands_;
+  bool last_cmd_zero_;
 
   void set_front_flipper_command(double vel);
 
@@ -52,6 +53,8 @@ private:
   void reset_commands();
 
   void publish_commands();
+
+  bool check_current_cmd_is_zero();
 
 };
 } // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -3,15 +3,16 @@
 
 #include <hector_gamepad_manager/gamepad_function_plugin.hpp>
 
-#include "std_msgs/msg/float64_multi_array.hpp"
 #include "hector_gamepad_manager_plugins/controller_helper.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "std_msgs/msg/float64_multi_array.hpp"
 
 namespace hector_gamepad_manager_plugins
 {
 class FlipperPlugin : public hector_gamepad_manager::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node) override;
+  void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
   std::string getPluginName() override;
 
@@ -46,15 +47,19 @@ private:
   std::vector<double> vel_commands_;
   bool last_cmd_zero_;
 
-  void set_front_flipper_command(double vel);
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_handler_;
 
-  void set_back_flipper_command(double vel);
+  void set_front_flipper_command( double vel );
+
+  void set_back_flipper_command( double vel );
 
   void reset_commands();
 
   void publish_commands();
 
   bool check_current_cmd_is_zero();
+
+  rcl_interfaces::msg::SetParametersResult set_params_cb(std::vector<rclcpp::Parameter> parameters);
 
 };
 } // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -1,0 +1,49 @@
+#ifndef HECTOR_GAMEPAD_MANAGER_PLUGINS_FLIPPER_PLUGIN_HPP
+#define HECTOR_GAMEPAD_MANAGER_PLUGINS_FLIPPER_PLUGIN_HPP
+
+#include <hector_gamepad_manager/gamepad_function_plugin.hpp>
+
+#include "std_msgs/msg/float64_multi_array.hpp"
+
+namespace hector_gamepad_manager_plugins
+{
+class FlipperPlugin : public hector_gamepad_manager::GamepadFunctionPlugin
+{
+public:
+  void initialize( const rclcpp::Node::SharedPtr &node, const bool active ) override;
+
+  void handleButton( const std::string &function, const bool pressed ) override;
+
+  void handleAxis( const std::string &function, const double value ) override;
+
+  void update() override;
+
+  void activate() override;
+
+  void deactivate() override;
+
+private:
+  rclcpp::Node::SharedPtr node_;
+
+  rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr flipper_command_publisher_;
+
+  double speed_;
+  double flipper_front_factor_;
+  double flipper_back_factor_;
+
+  std_msgs::msg::Float64MultiArray flipper_speed_commands_;
+
+  std::vector<double> vel_commands_;
+
+  void set_front_flipper_command(double vel);
+
+  void set_back_flipper_command(double vel);
+
+  void reset_commands();
+
+  void publish_commands();
+
+};
+} // namespace hector_gamepad_manager_plugins
+
+#endif // HECTOR_GAMEPAD_MANAGER_PLUGINS_DRIVE_PLUGIN_HPP

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -18,7 +18,7 @@ public:
 
   void handlePress( const std::string &function ) override;
 
-  void handleHold( const std::string &function ) override;
+  void handleRelease( const std::string &function ) override;
 
   void handleAxis( const std::string &function, const double value ) override;
 
@@ -44,22 +44,23 @@ private:
 
   std_msgs::msg::Float64MultiArray flipper_speed_commands_;
 
+  std::vector<double> button_vel_commands_;
+  std::vector<double> axis_vel_commands_;
   std::vector<double> vel_commands_;
+
   bool last_cmd_zero_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_handler_;
 
-  void set_front_flipper_command( double vel );
+  void handleUserInput( double base_speed_factor, bool is_button, const std::string &function );
 
-  void set_back_flipper_command( double vel );
+  void resetCommands();
 
-  void reset_commands();
+  void publishCommands();
 
-  void publish_commands();
+  bool checkCurrentCmdIsZero();
 
-  bool check_current_cmd_is_zero();
-
-  rcl_interfaces::msg::SetParametersResult set_params_cb(std::vector<rclcpp::Parameter> parameters);
+  rcl_interfaces::msg::SetParametersResult setParamsCb(std::vector<rclcpp::Parameter> parameters);
 
 };
 } // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_manager_plugins/package.xml
+++ b/hector_gamepad_manager_plugins/package.xml
@@ -12,6 +12,8 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>controller_manager_msgs</depend>
+
   <depend>hector_gamepad_manager</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/hector_gamepad_manager_plugins/plugins.xml
+++ b/hector_gamepad_manager_plugins/plugins.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <library path="hector_gamepad_manager_plugins">
-    <class type="hector_gamepad_manager_plugins::FlipperPlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
-        <description>Flipper functionality plugin</description>
-    </class>
     <class type="hector_gamepad_manager_plugins::DrivePlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
         <description>Drive functionality plugin</description>
+    </class>
+    <class type="hector_gamepad_manager_plugins::FlipperPlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
+        <description>Flipper functionality plugin</description>
     </class>
 </library>

--- a/hector_gamepad_manager_plugins/plugins.xml
+++ b/hector_gamepad_manager_plugins/plugins.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <library path="hector_gamepad_manager_plugins">
+    <class type="hector_gamepad_manager_plugins::FlipperPlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
+        <description>Flipper functionality plugin</description>
+    </class>
     <class type="hector_gamepad_manager_plugins::DrivePlugin" base_class_type="hector_gamepad_manager::GamepadFunctionPlugin">
         <description>Drive functionality plugin</description>
     </class>

--- a/hector_gamepad_manager_plugins/src/controller_helper.cpp
+++ b/hector_gamepad_manager_plugins/src/controller_helper.cpp
@@ -3,152 +3,99 @@
 namespace hector_gamepad_manager_plugins
 {
 
-    void ControllerHelper::initialize(const rclcpp::Node::SharedPtr &node, std::string plugin_name){
+void ControllerHelper::initialize( const rclcpp::Node::SharedPtr &node, std::string plugin_name )
+{
 
-        node_ = node;
+  node_ = node;
 
-        std::string switch_controllers_srv = "/" + node_->get_parameter("robot_namespace").as_string() + "/controller_manager/switch_controller";
-        switch_controller_client_ = node->create_client<controller_manager_msgs::srv::SwitchController>(switch_controllers_srv);
-        std::string list_controllers_srv = "/" + node_->get_parameter("robot_namespace").as_string() + "/controller_manager/list_controllers";
-        list_controllers_client_ = node->create_client<controller_manager_msgs::srv::ListControllers>(list_controllers_srv);
+  std::string switch_controllers_srv = "/" + node_->get_parameter( "robot_namespace" ).as_string() +
+                                       "/controller_manager/switch_controller";
+  switch_controller_client_ =
+      node->create_client<controller_manager_msgs::srv::SwitchController>( switch_controllers_srv );
+  std::string list_controllers_srv = "/" + node_->get_parameter( "robot_namespace" ).as_string() +
+                                     "/controller_manager/list_controllers";
+  list_controllers_client_ =
+      node->create_client<controller_manager_msgs::srv::ListControllers>( list_controllers_srv );
 
-        max_switch_tries_ = 2;
+  max_switch_tries_ = 2;
 
-        max_wait_on_srv_tries_ = 20;
-        switch_retry_sleep_rate_ = 20;
-        init_srv_timeout_ = 3000000000;     // 3s
-        regular_srv_timeout_ = 1000000000;  // 1s
+  max_wait_on_srv_tries_ = 20;
+  regular_srv_timeout_ = 10000; // 1s
 
-        plugin_name_ = plugin_name;
-        
-    }
-
-    void ControllerHelper::switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers){
-
-        if (start_controllers.empty() && stop_controllers.empty())
-            return;
-
-        RCLCPP_INFO(node_->get_logger(), "Initiating controller switch for %s plugin", plugin_name_.c_str());
-
-        std::chrono::nanoseconds wait_dur = std::chrono::nanoseconds(regular_srv_timeout_);
-        int wait_on_srv_tries = 0;
-        while (!switch_controller_client_->wait_for_service(wait_dur) && !list_controllers_client_->wait_for_service(wait_dur)) {
-
-            if (!rclcpp::ok()){ 
-                RCLCPP_ERROR(node_->get_logger(), "Interrupted while waiting for control manager services. Exiting.");
-                return;
-            }
-
-            wait_on_srv_tries++;
-            if(wait_on_srv_tries > max_wait_on_srv_tries_){
-                RCLCPP_ERROR(node_->get_logger(), "Maximum waiting for service tries exceeded");
-                return;
-            }
-        }
-
-        list_controllers_client_->async_send_request(
-            std::make_shared<controller_manager_msgs::srv::ListControllers::Request>(),
-            [this, start_controllers, stop_controllers](rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response) {
-                this->controller_list_cb(response, start_controllers, stop_controllers);
-            });
-    }
-
-void ControllerHelper::controller_list_cb(rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response,
-                                        std::vector<std::string> start_controllers, 
-                                        std::vector<std::string> stop_controllers){
-
-    auto list_response = response.get();
-
-    RCLCPP_INFO(node_->get_logger(), "Got list response");
-
-    // Get controller list to check if the controllers are already running or stopped
-    if (!list_response->controller.empty())
-        {
-
-            for (auto& controller : list_response->controller)
-            {
-
-                // check if current controller name is in one of the start/stop lists
-                auto start_iter = std::find(start_controllers.begin(), start_controllers.end(), controller.name);
-                auto stop_iter = std::find(stop_controllers.begin(), stop_controllers.end(), controller.name);
-
-                // if the controller was found in one of the lists and has the desired state, do not try to change the state later
-                if (start_iter != start_controllers.end() && controller.state == "running")
-                {
-                    start_controllers.erase(start_iter);
-                } else if (stop_iter != stop_controllers.end()
-                    && (controller.state == "stopped" || controller.state == "initialized"))
-                {
-                    stop_controllers.erase(stop_iter);
-                }
-            }
-        }
-    
-    // if everything is running/stopped, return
-    if (start_controllers.empty() && stop_controllers.empty())
-        return;
-
-    // fill service request
-    auto switch_request = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
-    switch_request->activate_controllers = start_controllers;
-    switch_request->deactivate_controllers = stop_controllers;
-    switch_request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
-    switch_request->activate_asap = false;
-    switch_request->timeout = rclcpp::Duration(0, 0);
-
-    RCLCPP_INFO(node_->get_logger(), "Attempting controller switch for %s plugin", plugin_name_.c_str());
-    if(!start_controllers.empty())
-        RCLCPP_INFO(node_->get_logger(), "Activating %s", start_controllers[0].c_str());
-    if(!stop_controllers.empty())
-        RCLCPP_INFO(node_->get_logger(), "Deactivating %s", stop_controllers[0].c_str());
-    
-    switch_controller_client_->async_send_request(switch_request, std::bind(&ControllerHelper::switch_controller_cb, this, std::placeholders::_1));
-
+  plugin_name_ = plugin_name;
 }
 
+void ControllerHelper::switchControllers( std::vector<std::string> start_controllers,
+                                          std::vector<std::string> stop_controllers )
+{
 
-void ControllerHelper::switch_controller_cb(rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response){
-    RCLCPP_INFO(node_->get_logger(), "Got switch response");
+  if ( start_controllers.empty() && stop_controllers.empty() )
+    return;
 
-    if (response.get()->ok)
-    {
-        RCLCPP_INFO(node_->get_logger(), "Successful controller switch for plugin %s", plugin_name_.c_str());
-    }
+  std::chrono::nanoseconds wait_dur = std::chrono::nanoseconds( regular_srv_timeout_ );
+  switch_controller_client_->wait_for_service( wait_dur );
+  list_controllers_client_->wait_for_service( wait_dur );
+
+  list_controllers_client_->async_send_request(
+      std::make_shared<controller_manager_msgs::srv::ListControllers::Request>(),
+      [this, start_controllers, stop_controllers](
+          rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response ) {
+        this->controller_list_cb( response, start_controllers, stop_controllers );
+      } );
 }
 
+void ControllerHelper::controller_list_cb(
+    rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response,
+    std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers )
+{
 
-    /*rclcpp::Rate sleep_rate(switch_retry_sleep_rate_);
-    // try to switch controllers several times
-    for (int i = 0; i < max_switch_tries_; i++)
-    {
-        auto switch_result = switch_controller_client_->async_send_request(switch_request);
+  auto list_response = response.get();
 
-        try {
-            if(!(rclcpp::spin_until_future_complete(node_, switch_result, std::chrono::nanoseconds(init_srv_timeout_)) == rclcpp::FutureReturnCode::SUCCESS)){
-                RCLCPP_ERROR(node_->get_logger(), "Error while calling controller list service during initialising");
-                return false;
-            }
-        } catch (const std::runtime_error &e) {
-            if(!(switch_result.wait_for(std::chrono::nanoseconds(regular_srv_timeout_)) == std::future_status::ready)){
-                RCLCPP_ERROR(node_->get_logger(), "Error while calling controller list service");
-                return false;
-            }
-        }
+  // Get controller list to check if the controllers are already running or stopped
+  if ( !list_response->controller.empty() ) {
 
-        // try to switch controller, if successful: break
-        if (switch_result.get()->ok)
-        {
-            RCLCPP_INFO(node_->get_logger(), "Successful controller switch for plugin %s", plugin_name_.c_str());
-            return true;
-        }
+    for ( auto &controller : list_response->controller ) {
 
-        RCLCPP_INFO(node_->get_logger(), "Retrying controller switch for plugin %s", plugin_name_.c_str());
-        sleep_rate.sleep();
+      // check if current controller name is in one of the start/stop lists
+      auto start_iter =
+          std::find( start_controllers.begin(), start_controllers.end(), controller.name );
+      auto stop_iter = std::find( stop_controllers.begin(), stop_controllers.end(), controller.name );
+
+      // if the controller was found in one of the lists and has the desired state, do not try to change the state later
+      if ( start_iter != start_controllers.end() && controller.state == "running" ) {
+        start_controllers.erase( start_iter );
+      } else if ( stop_iter != stop_controllers.end() &&
+                  ( controller.state == "stopped" || controller.state == "initialized" ) ) {
+        stop_controllers.erase( stop_iter );
+      }
     }
+  }
 
-    RCLCPP_ERROR(node_->get_logger(), "Failed to switch controllers for plugin %s", plugin_name_.c_str());
-    return false;
+  // if everything is running/stopped, return
+  if ( start_controllers.empty() && stop_controllers.empty() )
+    return;
 
-    }*/
+  // fill service request
+  auto switch_request = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
+  switch_request->activate_controllers = start_controllers;
+  switch_request->deactivate_controllers = stop_controllers;
+  switch_request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
+  switch_request->activate_asap = false;
+  switch_request->timeout = rclcpp::Duration( 0, 0 );
 
+  switch_controller_client_->async_send_request(
+      switch_request,
+      std::bind( &ControllerHelper::switch_controller_cb, this, std::placeholders::_1 ) );
 }
+
+void ControllerHelper::switch_controller_cb(
+    rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response )
+{
+
+  if ( response.get()->ok ) {
+    RCLCPP_INFO( node_->get_logger(), "Successful controller switch for plugin %s",
+                 plugin_name_.c_str() );
+  }
+}
+
+} // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_manager_plugins/src/controller_helper.cpp
+++ b/hector_gamepad_manager_plugins/src/controller_helper.cpp
@@ -64,10 +64,10 @@ void ControllerHelper::controller_list_cb(
       auto stop_iter = std::find( stop_controllers.begin(), stop_controllers.end(), controller.name );
 
       // if the controller was found in one of the lists and has the desired state, do not try to change the state later
-      if ( start_iter != start_controllers.end() && controller.state == "running" ) {
+      if ( start_iter != start_controllers.end() && controller.state == "active" ) {
         start_controllers.erase( start_iter );
       } else if ( stop_iter != stop_controllers.end() &&
-                  ( controller.state == "stopped" || controller.state == "initialized" ) ) {
+                  ( controller.state == "inactive" || controller.state == "initialized" ) ) {
         stop_controllers.erase( stop_iter );
       }
     }
@@ -83,7 +83,7 @@ void ControllerHelper::controller_list_cb(
   switch_request->deactivate_controllers = stop_controllers;
   switch_request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
   switch_request->activate_asap = false;
-  switch_request->timeout = rclcpp::Duration( 0, 0 );
+  switch_request->timeout = rclcpp::Duration( 1, 0 );
 
   switch_controller_client_->async_send_request(
       switch_request,

--- a/hector_gamepad_manager_plugins/src/controller_helper.cpp
+++ b/hector_gamepad_manager_plugins/src/controller_helper.cpp
@@ -42,11 +42,11 @@ void ControllerHelper::switchControllers( std::vector<std::string> start_control
       std::make_shared<controller_manager_msgs::srv::ListControllers::Request>(),
       [this, start_controllers, stop_controllers](
           rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response ) {
-        this->controller_list_cb( response, start_controllers, stop_controllers );
+        this->controllerListCb( response, start_controllers, stop_controllers );
       } );
 }
 
-void ControllerHelper::controller_list_cb(
+void ControllerHelper::controllerListCb(
     rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedFuture response,
     std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers )
 {
@@ -87,10 +87,10 @@ void ControllerHelper::controller_list_cb(
 
   switch_controller_client_->async_send_request(
       switch_request,
-      std::bind( &ControllerHelper::switch_controller_cb, this, std::placeholders::_1 ) );
+      std::bind( &ControllerHelper::switchControllerCb, this, std::placeholders::_1 ) );
 }
 
-void ControllerHelper::switch_controller_cb(
+void ControllerHelper::switchControllerCb(
     rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedFuture response )
 {
 

--- a/hector_gamepad_manager_plugins/src/controller_helper.cpp
+++ b/hector_gamepad_manager_plugins/src/controller_helper.cpp
@@ -5,7 +5,7 @@ namespace hector_gamepad_manager_plugins
 
     ControllerHelper::ControllerHelper(const rclcpp::Node::SharedPtr &node){
 
-        node_ = node
+        node_ = node;
         std::string switch_controllers_srv = node->get_namespace() + "/controller_manager/switch_controllers";
         switch_controller_client_ = node->create_client<controller_manager_msgs::srv::SwitchController>(switch_controllers_srv);
         std::string list_controllers_srv = node->get_namespace() + "/controller_manager/list_controllers";
@@ -19,9 +19,9 @@ namespace hector_gamepad_manager_plugins
             return;
 
 
-        list_controllers_client_->async_send_request(std::make_shared<controller_manager_msgs::srv::ListControllers::Request> ());
+        auto list_result = list_controllers_client_->async_send_request(std::make_shared<controller_manager_msgs::srv::ListControllers::Request> ());
 
-        rclcpp::spin_until_future_complete(node, result)
+        rclcpp::spin_until_future_complete(node_, list_result);
         // get controller list to check if the controllers are already running or stopped
         if (list_controllers_client_.call(list_controllers_srv_) && !list_controllers_srv_.response.controller.empty())
         {

--- a/hector_gamepad_manager_plugins/src/controller_helper.cpp
+++ b/hector_gamepad_manager_plugins/src/controller_helper.cpp
@@ -1,0 +1,63 @@
+#include "hector_gamepad_manager_plugins/controller_helper.hpp"
+
+namespace hector_gamepad_manager_plugins
+{
+
+    ControllerHelper::ControllerHelper(const rclcpp::Node::SharedPtr &node){
+
+        node_ = node
+        std::string switch_controllers_srv = node->get_namespace() + "/controller_manager/switch_controllers";
+        switch_controller_client_ = node->create_client<controller_manager_msgs::srv::SwitchController>(switch_controllers_srv);
+        std::string list_controllers_srv = node->get_namespace() + "/controller_manager/list_controllers";
+        list_controllers_client_ = node->create_client<controller_manager_msgs::srv::ListControllers>(list_controllers_srv);
+        max_switch_tries_ = 5;
+    }
+
+    void ControllerHelper::switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controller){
+
+        if (start_controllers.empty() && stop_controllers.empty())
+            return;
+
+
+        list_controllers_client_->async_send_request(std::make_shared<controller_manager_msgs::srv::ListControllers::Request> ());
+
+        rclcpp::spin_until_future_complete(node, result)
+        // get controller list to check if the controllers are already running or stopped
+        if (list_controllers_client_.call(list_controllers_srv_) && !list_controllers_srv_.response.controller.empty())
+        {
+
+            for (auto& controller : list_controllers_srv_.response.controller)
+            {
+
+                // check if current controller name is in one of the start/stop lists
+                auto start_iter = std::find(start_controllers.begin(), start_controllers.end(), controller.name);
+                auto stop_iter = std::find(stop_controllers.begin(), stop_controllers.end(), controller.name);
+
+                // if the controller was found in one of the lists and has the desired state, do not try to change the state later
+                if (start_iter != start_controllers.end() && controller.state == "running")
+                {
+                    start_controllers.erase(start_iter);
+                } else if (stop_iter != stop_controllers.end()
+                    && (controller.state == "stopped" || controller.state == "initialized"))
+                {
+                    stop_controllers.erase(stop_iter);
+                }
+            }
+        }
+
+    // if everything is running/stopped, return
+    if (start_controllers.empty() && stop_controllers.empty())
+    {
+        return "";
+    }
+
+    // fill service request
+    switch_controller_srv_.request.start_controllers = start_controllers;
+    switch_controller_srv_.request.stop_controllers = stop_controllers;
+    switch_controller_srv_.request.strictness = controller_manager_msgs::SwitchController::Request::STRICT;
+    switch_controller_srv_.request.start_asap = false;
+    switch_controller_srv_.request.timeout = 0.0;
+
+    }
+
+}

--- a/hector_gamepad_manager_plugins/src/controller_helper.cpp
+++ b/hector_gamepad_manager_plugins/src/controller_helper.cpp
@@ -3,30 +3,55 @@
 namespace hector_gamepad_manager_plugins
 {
 
-    ControllerHelper::ControllerHelper(const rclcpp::Node::SharedPtr &node){
+    void ControllerHelper::initialize(const rclcpp::Node::SharedPtr &node, std::string plugin_name){
 
         node_ = node;
-        std::string switch_controllers_srv = node->get_namespace() + "/controller_manager/switch_controllers";
+
+        std::string switch_controllers_srv = "/" + node_->get_parameter("robot_namespace").as_string() + "/controller_manager/switch_controller";
         switch_controller_client_ = node->create_client<controller_manager_msgs::srv::SwitchController>(switch_controllers_srv);
-        std::string list_controllers_srv = node->get_namespace() + "/controller_manager/list_controllers";
+        std::string list_controllers_srv = "/" + node_->get_parameter("robot_namespace").as_string() + "/controller_manager/list_controllers";
+
         list_controllers_client_ = node->create_client<controller_manager_msgs::srv::ListControllers>(list_controllers_srv);
+
+        RCLCPP_INFO(node_->get_logger(), "Service name %s", switch_controllers_srv.c_str());
         max_switch_tries_ = 5;
+        max_wait_on_srv_tries_ = 5;
+        switch_sleep_rate_ = 100;
+
+        plugin_name_ = plugin_name;
     }
 
-    void ControllerHelper::switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controller){
+    bool ControllerHelper::switchControllers(std::vector<std::string> start_controllers, std::vector<std::string> stop_controllers){
 
         if (start_controllers.empty() && stop_controllers.empty())
-            return;
+            return true;
 
+        std::chrono::nanoseconds wait_dur = std::chrono::nanoseconds(1000000000);
+        int wait_on_srv_tries = 0;
+        while (!switch_controller_client_->wait_for_service(wait_dur) && !list_controllers_client_->wait_for_service(wait_dur)) {
+
+            if (!rclcpp::ok()) 
+                RCLCPP_ERROR(node_->get_logger(), "Interrupted while waiting for control manager services. Exiting.");
+
+            wait_on_srv_tries++;
+            if(wait_on_srv_tries > max_wait_on_srv_tries_){
+                RCLCPP_ERROR(node_->get_logger(), "Maximum waiting for service tries exceeded");
+                return false;
+            }
+        }
 
         auto list_result = list_controllers_client_->async_send_request(std::make_shared<controller_manager_msgs::srv::ListControllers::Request> ());
 
         rclcpp::spin_until_future_complete(node_, list_result);
+
+        RCLCPP_INFO(node_->get_logger(), "Future result received");
+
+        auto list_response = list_result.get();
         // get controller list to check if the controllers are already running or stopped
-        if (list_controllers_client_.call(list_controllers_srv_) && !list_controllers_srv_.response.controller.empty())
+        if (!list_response->controller.empty())
         {
 
-            for (auto& controller : list_controllers_srv_.response.controller)
+            for (auto& controller : list_response->controller)
             {
 
                 // check if current controller name is in one of the start/stop lists
@@ -47,16 +72,39 @@ namespace hector_gamepad_manager_plugins
 
     // if everything is running/stopped, return
     if (start_controllers.empty() && stop_controllers.empty())
-    {
-        return "";
-    }
+        return true;
 
     // fill service request
-    switch_controller_srv_.request.start_controllers = start_controllers;
-    switch_controller_srv_.request.stop_controllers = stop_controllers;
-    switch_controller_srv_.request.strictness = controller_manager_msgs::SwitchController::Request::STRICT;
-    switch_controller_srv_.request.start_asap = false;
-    switch_controller_srv_.request.timeout = 0.0;
+
+    auto switch_request = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
+    switch_request->activate_controllers = start_controllers;
+    switch_request->deactivate_controllers = stop_controllers;
+    switch_request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
+    switch_request->activate_asap = false;
+    switch_request->timeout = rclcpp::Duration(0, 0);
+
+    rclcpp::Rate sleep_rate(switch_sleep_rate_);
+
+    // try to switch controllers several times
+    for (int i = 0; i < max_switch_tries_; i++)
+    {
+        auto switch_result = switch_controller_client_->async_send_request(switch_request);
+
+        rclcpp::spin_until_future_complete(node_, switch_result);
+
+        // try to switch controller, if successful: break
+        if (switch_result.get()->ok)
+        {
+            RCLCPP_INFO(node_->get_logger(), "Successful controller switch for plugin %s", plugin_name_.c_str());
+            return true;
+        }
+
+        RCLCPP_INFO(node_->get_logger(), "Retrying controller switch for plugin %s", plugin_name_.c_str());
+        sleep_rate.sleep();
+    }
+
+    RCLCPP_ERROR(node_->get_logger(), "Failed to switch controllers for plugin %s", plugin_name_.c_str());
+    return false;
 
     }
 

--- a/hector_gamepad_manager_plugins/src/drive_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/drive_plugin.cpp
@@ -7,26 +7,30 @@ namespace hector_gamepad_manager_plugins
 void DrivePlugin::initialize( const rclcpp::Node::SharedPtr &node )
 {
   node_ = node;
-  plugin_namespace_ = "drive_plugin";
+  std::string plugin_namespace = getPluginName();
 
-  node_->declare_parameters<double>( plugin_namespace_, { { "max_linear_speed", 1.0 },
+  node_->declare_parameters<double>( plugin_namespace, { { "max_linear_speed", 1.0 },
                                                           { "max_angular_speed", 1.0 },
                                                           { "slow_factor", 0.5 },
                                                           { "normal_factor", 0.75 },
                                                           { "fast_factor", 1.0 } } );
 
-  max_linear_speed_ = node_->get_parameter( plugin_namespace_ + ".max_linear_speed" ).as_double();
+  max_linear_speed_ = node_->get_parameter( plugin_namespace + ".max_linear_speed" ).as_double();
 
-  max_angular_speed_ = node_->get_parameter( plugin_namespace_ + ".max_angular_speed" ).as_double();
+  max_angular_speed_ = node_->get_parameter( plugin_namespace + ".max_angular_speed" ).as_double();
 
-  slow_factor_ = node_->get_parameter( plugin_namespace_ + ".slow_factor" ).as_double();
+  slow_factor_ = node_->get_parameter( plugin_namespace + ".slow_factor" ).as_double();
 
-  normal_factor_ = node_->get_parameter( plugin_namespace_ + ".normal_factor" ).as_double();
+  normal_factor_ = node_->get_parameter( plugin_namespace + ".normal_factor" ).as_double();
 
-  fast_factor_ = node_->get_parameter( plugin_namespace_ + ".fast_factor" ).as_double();
+  fast_factor_ = node_->get_parameter( plugin_namespace + ".fast_factor" ).as_double();
 
   drive_command_publisher_ =
       node_->create_publisher<geometry_msgs::msg::TwistStamped>( "cmd_vel", 1 );
+}
+
+std::string DrivePlugin::getPluginName(){
+  return "drive_plugin";
 }
 
 void DrivePlugin::handleAxis( const std::string &function, const double value )

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -38,11 +38,11 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node)
 
 void FlipperPlugin::handlePress( const std::string &function)
 {
-  RCLCPP_INFO( node_->get_logger(), "Function: %s, Pressed", function.c_str());
 
   if ( !active_ ) 
     return;
 
+  RCLCPP_INFO( node_->get_logger(), "Function: %s, Pressed", function.c_str());
 
   if(function == "flipper_back_up") 
       set_back_flipper_command(speed_ * flipper_back_factor_);
@@ -54,11 +54,9 @@ void FlipperPlugin::handlePress( const std::string &function)
 
 void FlipperPlugin::handleHold( const std::string &function)
 {
-  RCLCPP_INFO( node_->get_logger(), "Function: %s Hold", function.c_str());
 
   if ( !active_ ) 
     return;
-
 
   if(function == "flipper_back_up") 
       set_back_flipper_command(speed_ * flipper_back_factor_);
@@ -70,7 +68,6 @@ void FlipperPlugin::handleHold( const std::string &function)
 
 void FlipperPlugin::handleAxis( const std::string &function, const double value )
 {
-  RCLCPP_INFO( node_->get_logger(), "Function: %s, Pressed", function.c_str());
 
   if ( !active_ )
     return;
@@ -93,7 +90,7 @@ void FlipperPlugin::update()
 }
 
 void FlipperPlugin::activate() {
-  //controller_helper_.switchControllers({teleop_controller_}, {standard_controller_}); 
+  controller_helper_.switchControllers({teleop_controller_}, {standard_controller_}); 
   active_ = true;
 }
 
@@ -105,17 +102,21 @@ void FlipperPlugin::deactivate()
   reset_commands();
   publish_commands();
 
-  //controller_helper_.switchControllers({standard_controller_}, {teleop_controller_}); 
+  controller_helper_.switchControllers({standard_controller_}, {teleop_controller_}); 
 } 
 
 void FlipperPlugin::set_front_flipper_command(double vel){
-  vel_commands_[0] = vel;
-  vel_commands_[1] = vel;
+  // To avoid ovveride of trigger cmd from bumber zero_val add vel
+  // Vel commands are reset after every update call
+  vel_commands_[0] += vel;
+  vel_commands_[1] += vel;
 }
 
 void FlipperPlugin::set_back_flipper_command(double vel){
-  vel_commands_[2] = vel;
-  vel_commands_[3] = vel;
+  // To avoid ovveride of trigger cmd from bumber zero_val add vel
+  // Vel commands are reset after every update call
+  vel_commands_[2] += vel;
+  vel_commands_[3] += vel;
 }
 
 void FlipperPlugin::reset_commands(){

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -1,0 +1,104 @@
+#include "hector_gamepad_manager_plugins/flipper_plugin.hpp"
+
+namespace hector_gamepad_manager_plugins
+{
+
+void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node, const bool active )
+{
+  node_ = node;
+  active_ = active;
+
+  plugin_namespace_ = "flipper_plugin";
+
+  node_->declare_parameters<double>( plugin_namespace_, {{ "speed", 1.5 },
+                                                         { "flipper_front_factor", 1.0 },
+                                                         { "flipper_back_factor", 1.0 }});
+
+  speed_ = node_->get_parameter( plugin_namespace_ + ".speed" ).as_double();
+  flipper_front_factor_ = node_->get_parameter( plugin_namespace_ + ".flipper_front_factor" ).as_double();
+  flipper_back_factor_ = node_->get_parameter( plugin_namespace_ + ".flipper_back_factor" ).as_double();
+
+  // ros controller mapping [fr_l, fr_r, b_l, b_r]
+  vel_commands_.insert(vel_commands_.begin(), {0.0, 0.0, 0.0, 0.0});
+
+  flipper_command_publisher_ =
+      node_->create_publisher<std_msgs::msg::Float64MultiArray>("/flipper_controller_teleop/commands", 10 );
+}
+
+void FlipperPlugin::handleButton( const std::string &function, const bool pressed )
+{
+  if ( !active_ ) 
+    return;
+
+  RCLCPP_INFO( node_->get_logger(), "Function: %s, Pressed: %d", function.c_str(), pressed);
+
+  if(function == "flipper_back_up" && pressed) 
+      set_back_flipper_command(speed_ * flipper_back_factor_);
+
+  if(function == "flipper_front_up" && pressed)
+      set_front_flipper_command(speed_ * flipper_front_factor_);
+
+}
+
+void FlipperPlugin::handleAxis( const std::string &function, const double value )
+{
+  if ( !active_ )
+    return;
+
+  if(function == "flipper_back_down")
+    set_back_flipper_command(- speed_ * flipper_back_factor_ * value);
+
+  if(function == "flipper_front_down")
+    set_front_flipper_command(- speed_ * flipper_front_factor_ * value);
+  
+}
+
+void FlipperPlugin::update()
+{
+  if ( !active_ ) 
+    return;  
+
+  publish_commands();
+  reset_commands();
+}
+
+void FlipperPlugin::activate() { active_ = true;  }
+
+void FlipperPlugin::deactivate()
+{
+  active_ = false;
+
+  reset_commands();
+  //Publish null velocity command
+  publish_commands();
+} 
+
+void FlipperPlugin::set_front_flipper_command(double vel){
+  vel_commands_[0] = vel;
+  vel_commands_[1] = vel;
+}
+
+void FlipperPlugin::set_back_flipper_command(double vel){
+  vel_commands_[2] = vel;
+  vel_commands_[3] = vel;
+}
+
+void FlipperPlugin::reset_commands(){
+  vel_commands_[0] = 0.0;
+  vel_commands_[1] = 0.0;
+  vel_commands_[2] = 0.0;
+  vel_commands_[3] = 0.0;
+}
+
+void FlipperPlugin::publish_commands(){
+  std_msgs::msg::Float64MultiArray cmd_msg;
+  cmd_msg.data = vel_commands_;
+  flipper_command_publisher_->publish(cmd_msg);
+}
+
+}// namespace hector_gamepad_manager_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS( hector_gamepad_manager_plugins::FlipperPlugin,
+                        hector_gamepad_manager::GamepadFunctionPlugin )

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -30,14 +30,16 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   teleop_controller_ = node_->get_parameter( plugin_namespace + ".teleop_controller" ).as_string();
 
   param_cb_handler_ = node->add_on_set_parameters_callback(
-      std::bind( &FlipperPlugin::set_params_cb, this, std::placeholders::_1 ) );
+      std::bind( &FlipperPlugin::setParamsCb, this, std::placeholders::_1 ) );
 
   // ros controller mapping [fr_l, fr_r, b_l, b_r]
   vel_commands_.insert( vel_commands_.begin(), { 0.0, 0.0, 0.0, 0.0 } );
+  axis_vel_commands_.insert( axis_vel_commands_.begin(), { 0.0, 0.0, 0.0, 0.0 } );
+  button_vel_commands_.insert( button_vel_commands_.begin(), { 0.0, 0.0, 0.0, 0.0 } );
 
   flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
-      "/" + node_->get_parameter( "robot_namespace" ).as_string() +
-          "/" + teleop_controller_ + "/commands",
+      "/" + node_->get_parameter( "robot_namespace" ).as_string() + "/" + teleop_controller_ +
+          "/commands",
       10 );
 
   controller_helper_.initialize( node, plugin_namespace );
@@ -45,7 +47,7 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
 }
 
 rcl_interfaces::msg::SetParametersResult
-FlipperPlugin::set_params_cb( std::vector<rclcpp::Parameter> parameters )
+FlipperPlugin::setParamsCb( std::vector<rclcpp::Parameter> parameters )
 {
   auto result = rcl_interfaces::msg::SetParametersResult();
   result.successful = true;
@@ -76,41 +78,17 @@ std::string FlipperPlugin::getPluginName() { return "flipper_plugin"; }
 
 void FlipperPlugin::handlePress( const std::string &function )
 {
-
-  if ( !active_ )
-    return;
-
-  if ( function == "flipper_back_up" )
-    set_back_flipper_command( speed_ * flipper_back_factor_ );
-
-  if ( function == "flipper_front_up" )
-    set_front_flipper_command( speed_ * flipper_front_factor_ );
+  handleUserInput( 1, true, function );
 }
 
-void FlipperPlugin::handleHold( const std::string &function )
+void FlipperPlugin::handleRelease( const std::string &function )
 {
-
-  if ( !active_ )
-    return;
-
-  if ( function == "flipper_back_up" )
-    set_back_flipper_command( speed_ * flipper_back_factor_ );
-
-  if ( function == "flipper_front_up" )
-    set_front_flipper_command( speed_ * flipper_front_factor_ );
+  handleUserInput( 0, true, function );
 }
 
 void FlipperPlugin::handleAxis( const std::string &function, const double value )
 {
-
-  if ( !active_ )
-    return;
-
-  if ( function == "flipper_back_down" )
-    set_back_flipper_command( -speed_ * flipper_back_factor_ * value );
-
-  if ( function == "flipper_front_down" )
-    set_front_flipper_command( -speed_ * flipper_front_factor_ * value );
+  handleUserInput( -1 * value, false, function );
 }
 
 void FlipperPlugin::update()
@@ -118,14 +96,18 @@ void FlipperPlugin::update()
   if ( !active_ )
     return;
 
-  bool current_cmd_zero = check_current_cmd_is_zero();
+  vel_commands_[0] = axis_vel_commands_[0] + button_vel_commands_[0];
+  vel_commands_[1] = axis_vel_commands_[1] + button_vel_commands_[1];
+  vel_commands_[2] = axis_vel_commands_[2] + button_vel_commands_[2];
+  vel_commands_[3] = axis_vel_commands_[3] + button_vel_commands_[3];
+
+  bool current_cmd_zero = checkCurrentCmdIsZero();
 
   if ( last_cmd_zero_ && !current_cmd_zero )
     controller_helper_.switchControllers( { teleop_controller_ }, { standard_controller_ } );
 
   if ( !( last_cmd_zero_ && current_cmd_zero ) )
-    publish_commands();
-  reset_commands();
+    publishCommands();
   last_cmd_zero_ = current_cmd_zero;
 }
 
@@ -140,27 +122,44 @@ void FlipperPlugin::deactivate()
   active_ = false;
 
   // Publish null velocity command
-  reset_commands();
-  publish_commands();
+  resetCommands();
+  publishCommands();
 }
 
-void FlipperPlugin::set_front_flipper_command( double vel )
+void FlipperPlugin::handleUserInput( double base_speed_factor, bool is_button,
+                                  const std::string &function )
 {
-  // To avoid ovveride of trigger cmd from bumber zero_val add vel
-  // Vel commands are reset after every update call
-  vel_commands_[0] += vel;
-  vel_commands_[1] += vel;
+  if ( !active_ )
+    return;
+
+  double vel = speed_ * base_speed_factor;
+
+  if ( function == "flipper_back_up" || function == "flipper_back_down" ) {
+    vel *= flipper_back_factor_;
+
+    if ( is_button ) {
+      button_vel_commands_[2] = vel;
+      button_vel_commands_[3] = vel;
+    } else {
+      axis_vel_commands_[2] = vel;
+      axis_vel_commands_[3] = vel;
+    }
+  }
+
+  if ( function == "flipper_front_up" || function == "flipper_front_down" ) {
+    vel *= flipper_front_factor_;
+
+    if ( is_button ) {
+      button_vel_commands_[0] = vel;
+      button_vel_commands_[1] = vel;
+    } else {
+      axis_vel_commands_[0] = vel;
+      axis_vel_commands_[1] = vel;
+    }
+  }
 }
 
-void FlipperPlugin::set_back_flipper_command( double vel )
-{
-  // To avoid ovveride of trigger cmd from bumber zero_val add vel
-  // Vel commands are reset after every update call
-  vel_commands_[2] += vel;
-  vel_commands_[3] += vel;
-}
-
-void FlipperPlugin::reset_commands()
+void FlipperPlugin::resetCommands()
 {
   vel_commands_[0] = 0.0;
   vel_commands_[1] = 0.0;
@@ -168,14 +167,14 @@ void FlipperPlugin::reset_commands()
   vel_commands_[3] = 0.0;
 }
 
-void FlipperPlugin::publish_commands()
+void FlipperPlugin::publishCommands()
 {
   std_msgs::msg::Float64MultiArray cmd_msg;
   cmd_msg.data = vel_commands_;
   flipper_command_publisher_->publish( cmd_msg );
 }
 
-bool FlipperPlugin::check_current_cmd_is_zero()
+bool FlipperPlugin::checkCurrentCmdIsZero()
 {
   for ( double cmd : vel_commands_ ) {
     if ( cmd != 0.0 )

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -3,67 +3,101 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node)
+void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
 {
   node_ = node;
 
   std::string plugin_namespace = getPluginName();
 
-  node_->declare_parameters<double>( plugin_namespace, {{ "speed", 1.5 },
-                                                         { "flipper_front_factor", 1.0 },
-                                                         { "flipper_back_factor", 1.0 },
-                                                         });
-  node_->declare_parameters<std::string>(plugin_namespace, {{ "standard_controller", "flipper_controller" },
-                                                         { "teleop_controller", "flipper_controller_teleop" },
-                                                         });
+  node_->declare_parameters<double>( plugin_namespace, {
+                                                           { "speed", 1.5 },
+                                                           { "flipper_front_factor", 1.0 },
+                                                           { "flipper_back_factor", 1.0 },
+                                                       } );
+  node_->declare_parameters<std::string>( plugin_namespace,
+                                          {
+                                              { "standard_controller", "flipper_controller" },
+                                              { "teleop_controller", "flipper_controller_teleop" },
+                                          } );
 
   speed_ = node_->get_parameter( plugin_namespace + ".speed" ).as_double();
-  flipper_front_factor_ = node_->get_parameter( plugin_namespace + ".flipper_front_factor" ).as_double();
-  flipper_back_factor_ = node_->get_parameter( plugin_namespace + ".flipper_back_factor" ).as_double();
-  standard_controller_ = node_->get_parameter( plugin_namespace + ".standard_controller" ).as_string();
+  flipper_front_factor_ =
+      node_->get_parameter( plugin_namespace + ".flipper_front_factor" ).as_double();
+  flipper_back_factor_ =
+      node_->get_parameter( plugin_namespace + ".flipper_back_factor" ).as_double();
+  standard_controller_ =
+      node_->get_parameter( plugin_namespace + ".standard_controller" ).as_string();
   teleop_controller_ = node_->get_parameter( plugin_namespace + ".teleop_controller" ).as_string();
 
+  param_cb_handler_ = node->add_on_set_parameters_callback(
+      std::bind( &FlipperPlugin::set_params_cb, this, std::placeholders::_1 ) );
+
   // ros controller mapping [fr_l, fr_r, b_l, b_r]
-  vel_commands_.insert(vel_commands_.begin(), {0.0, 0.0, 0.0, 0.0});
+  vel_commands_.insert( vel_commands_.begin(), { 0.0, 0.0, 0.0, 0.0 } );
 
-  flipper_command_publisher_ =
-      node_->create_publisher<std_msgs::msg::Float64MultiArray>("/" + node_->get_parameter("robot_namespace").as_string() + "/flipper_controller_teleop/commands", 10 );
-  
-  controller_helper_.initialize(node, plugin_namespace);
-  active_=true;
-    
+  flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
+      "/" + node_->get_parameter( "robot_namespace" ).as_string() +
+          "/flipper_controller_teleop/commands",
+      10 );
+
+  controller_helper_.initialize( node, plugin_namespace );
+  active_ = true;
 }
 
-std::string FlipperPlugin::getPluginName(){
-  return "flipper_plugin";
+rcl_interfaces::msg::SetParametersResult
+FlipperPlugin::set_params_cb( std::vector<rclcpp::Parameter> parameters )
+{
+  auto result = rcl_interfaces::msg::SetParametersResult();
+  result.successful = true;
+
+  for ( auto parameter : parameters ) {
+
+    double val = parameter.as_double();
+    if ( val <= 0 ) {
+      result.successful = false;
+      result.reason = "Can't set a negative or null speed for: " + parameter.get_name();
+      break;
+    }
+
+    if ( parameter.get_name() == "speed" )
+      speed_ = val;
+
+    if ( parameter.get_name() == "flipper_front_factor" )
+      flipper_front_factor_ = val;
+
+    if ( parameter.get_name() == "flipper_back_factor" )
+      flipper_back_factor_ = val;
+  }
+
+  return result;
 }
 
-void FlipperPlugin::handlePress( const std::string &function)
+std::string FlipperPlugin::getPluginName() { return "flipper_plugin"; }
+
+void FlipperPlugin::handlePress( const std::string &function )
 {
 
-  if ( !active_ ) 
+  if ( !active_ )
     return;
 
-  if(function == "flipper_back_up") 
-      set_back_flipper_command(speed_ * flipper_back_factor_);
+  if ( function == "flipper_back_up" )
+    set_back_flipper_command( speed_ * flipper_back_factor_ );
 
-  if(function == "flipper_front_up")
-      set_front_flipper_command(speed_ * flipper_front_factor_);
-
+  if ( function == "flipper_front_up" )
+    set_front_flipper_command( speed_ * flipper_front_factor_ );
 }
 
-void FlipperPlugin::handleHold( const std::string &function)
+void FlipperPlugin::handleHold( const std::string &function )
 {
 
-  if ( !active_ ) 
+  if ( !active_ )
     return;
 
-  if(function == "flipper_back_up") 
-      set_back_flipper_command(speed_ * flipper_back_factor_);
+  if ( function == "flipper_back_up" )
+    set_back_flipper_command( speed_ * flipper_back_factor_ );
 
-  if(function == "flipper_front_up")
-      set_front_flipper_command(speed_ * flipper_front_factor_);
-
+  if ( function == "flipper_front_up" )
+    set_front_flipper_command( speed_ * flipper_front_factor_ );
 }
 
 void FlipperPlugin::handleAxis( const std::string &function, const double value )
@@ -72,83 +106,85 @@ void FlipperPlugin::handleAxis( const std::string &function, const double value 
   if ( !active_ )
     return;
 
-  if(function == "flipper_back_down")
-    set_back_flipper_command(- speed_ * flipper_back_factor_ * value);
+  if ( function == "flipper_back_down" )
+    set_back_flipper_command( -speed_ * flipper_back_factor_ * value );
 
-  if(function == "flipper_front_down")
-    set_front_flipper_command(- speed_ * flipper_front_factor_ * value);
-  
+  if ( function == "flipper_front_down" )
+    set_front_flipper_command( -speed_ * flipper_front_factor_ * value );
 }
 
 void FlipperPlugin::update()
 {
-  if (!active_) 
+  if ( !active_ )
     return;
 
   bool current_cmd_zero = check_current_cmd_is_zero();
 
-  if(last_cmd_zero_ && !current_cmd_zero)
-    controller_helper_.switchControllers({teleop_controller_}, {standard_controller_}); 
-    
+  if ( last_cmd_zero_ && !current_cmd_zero )
+    controller_helper_.switchControllers( { teleop_controller_ }, { standard_controller_ } );
 
-  if(!(last_cmd_zero_ && current_cmd_zero))
+  if ( !( last_cmd_zero_ && current_cmd_zero ) )
     publish_commands();
   reset_commands();
   last_cmd_zero_ = current_cmd_zero;
 }
 
-void FlipperPlugin::activate() {
+void FlipperPlugin::activate()
+{
   active_ = true;
-  last_cmd_zero_=false;
+  last_cmd_zero_ = false;
 }
 
 void FlipperPlugin::deactivate()
 {
   active_ = false;
 
-  //Publish null velocity command
+  // Publish null velocity command
   reset_commands();
   publish_commands();
+}
 
-} 
-
-void FlipperPlugin::set_front_flipper_command(double vel){
+void FlipperPlugin::set_front_flipper_command( double vel )
+{
   // To avoid ovveride of trigger cmd from bumber zero_val add vel
   // Vel commands are reset after every update call
   vel_commands_[0] += vel;
   vel_commands_[1] += vel;
 }
 
-void FlipperPlugin::set_back_flipper_command(double vel){
+void FlipperPlugin::set_back_flipper_command( double vel )
+{
   // To avoid ovveride of trigger cmd from bumber zero_val add vel
   // Vel commands are reset after every update call
   vel_commands_[2] += vel;
   vel_commands_[3] += vel;
 }
 
-void FlipperPlugin::reset_commands(){
+void FlipperPlugin::reset_commands()
+{
   vel_commands_[0] = 0.0;
   vel_commands_[1] = 0.0;
   vel_commands_[2] = 0.0;
   vel_commands_[3] = 0.0;
 }
 
-void FlipperPlugin::publish_commands(){
+void FlipperPlugin::publish_commands()
+{
   std_msgs::msg::Float64MultiArray cmd_msg;
   cmd_msg.data = vel_commands_;
-  flipper_command_publisher_->publish(cmd_msg);
+  flipper_command_publisher_->publish( cmd_msg );
 }
 
-bool FlipperPlugin::check_current_cmd_is_zero(){
- for(double cmd : vel_commands_){
-   if(cmd != 0.0)
-     return false;
- }
- return true;
+bool FlipperPlugin::check_current_cmd_is_zero()
+{
+  for ( double cmd : vel_commands_ ) {
+    if ( cmd != 0.0 )
+      return false;
+  }
+  return true;
 }
 
-
-}// namespace hector_gamepad_manager_plugins
+} // namespace hector_gamepad_manager_plugins
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -37,7 +37,7 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
 
   flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
       "/" + node_->get_parameter( "robot_namespace" ).as_string() +
-          "/flipper_controller_teleop/commands",
+          "/" + teleop_controller_ + "/commands",
       10 );
 
   controller_helper_.initialize( node, plugin_namespace );

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -7,21 +7,21 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node)
 {
   node_ = node;
 
-  plugin_namespace_ = "flipper_plugin";
+  std::string plugin_namespace = getPluginName();
 
-  node_->declare_parameters<double>( plugin_namespace_, {{ "speed", 1.5 },
+  node_->declare_parameters<double>( plugin_namespace, {{ "speed", 1.5 },
                                                          { "flipper_front_factor", 1.0 },
                                                          { "flipper_back_factor", 1.0 },
                                                          });
-  node_->declare_parameters<std::string>(plugin_namespace_, {{ "standard_controller", "flipper_controller" },
+  node_->declare_parameters<std::string>(plugin_namespace, {{ "standard_controller", "flipper_controller" },
                                                          { "teleop_controller", "flipper_controller_teleop" },
                                                          });
 
-  speed_ = node_->get_parameter( plugin_namespace_ + ".speed" ).as_double();
-  flipper_front_factor_ = node_->get_parameter( plugin_namespace_ + ".flipper_front_factor" ).as_double();
-  flipper_back_factor_ = node_->get_parameter( plugin_namespace_ + ".flipper_back_factor" ).as_double();
-  standard_controller_ = node_->get_parameter( plugin_namespace_ + ".standard_controller" ).as_string();
-  teleop_controller_ = node_->get_parameter( plugin_namespace_ + ".teleop_controller" ).as_string();
+  speed_ = node_->get_parameter( plugin_namespace + ".speed" ).as_double();
+  flipper_front_factor_ = node_->get_parameter( plugin_namespace + ".flipper_front_factor" ).as_double();
+  flipper_back_factor_ = node_->get_parameter( plugin_namespace + ".flipper_back_factor" ).as_double();
+  standard_controller_ = node_->get_parameter( plugin_namespace + ".standard_controller" ).as_string();
+  teleop_controller_ = node_->get_parameter( plugin_namespace + ".teleop_controller" ).as_string();
 
   // ros controller mapping [fr_l, fr_r, b_l, b_r]
   vel_commands_.insert(vel_commands_.begin(), {0.0, 0.0, 0.0, 0.0});
@@ -29,11 +29,15 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node)
   flipper_command_publisher_ =
       node_->create_publisher<std_msgs::msg::Float64MultiArray>("/" + node_->get_parameter("robot_namespace").as_string() + "/flipper_controller_teleop/commands", 10 );
   
-  controller_helper_.initialize(node, "flipper_plugin");
+  controller_helper_.initialize(node, plugin_namespace);
   RCLCPP_INFO( node_->get_logger(), "Attempting controller switch");
 
   active_=true;
     
+}
+
+std::string FlipperPlugin::getPluginName(){
+  return "flipper_plugin";
 }
 
 void FlipperPlugin::handlePress( const std::string &function)

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -100,7 +100,7 @@ void FlipperPlugin::update()
 }
 
 void FlipperPlugin::activate() {
-  controller_helper_.switchControllers({teleop_controller_}, {standard_controller_}); 
+  //controller_helper_.switchControllers({teleop_controller_}, {standard_controller_}); 
   active_ = true;
   last_cmd_zero_=false;
 }
@@ -113,7 +113,7 @@ void FlipperPlugin::deactivate()
   reset_commands();
   publish_commands();
 
-  controller_helper_.switchControllers({standard_controller_}, {teleop_controller_}); 
+  //controller_helper_.switchControllers({standard_controller_}, {teleop_controller_}); 
 } 
 
 void FlipperPlugin::set_front_flipper_command(double vel){

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -30,8 +30,6 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node)
       node_->create_publisher<std_msgs::msg::Float64MultiArray>("/" + node_->get_parameter("robot_namespace").as_string() + "/flipper_controller_teleop/commands", 10 );
   
   controller_helper_.initialize(node, plugin_namespace);
-  RCLCPP_INFO( node_->get_logger(), "Attempting controller switch");
-
   active_=true;
     
 }
@@ -100,7 +98,6 @@ void FlipperPlugin::update()
 }
 
 void FlipperPlugin::activate() {
-  //controller_helper_.switchControllers({teleop_controller_}, {standard_controller_}); 
   active_ = true;
   last_cmd_zero_=false;
 }
@@ -113,7 +110,6 @@ void FlipperPlugin::deactivate()
   reset_commands();
   publish_commands();
 
-  //controller_helper_.switchControllers({standard_controller_}, {teleop_controller_}); 
 } 
 
 void FlipperPlugin::set_front_flipper_command(double vel){


### PR DESCRIPTION
Add plugin for flipper teleop control.
Includes ported controller_helper used to switch active ros controllers as needed. Depends on athena_simulation and athena_description merge requests. Also, hector_ros_controllers/jazzy is needed.