### PR TITLE
Feature/view control

### DIFF
--- a/hector_gamepad_manager/config/athena.yaml
+++ b/hector_gamepad_manager/config/athena.yaml
@@ -36,8 +36,8 @@ buttons:
    config: "driving"
 
   8: # Button Guide (Manufacturer Button)
-   package: ""
-   config: ""
+   package: "hector_gamepad_manager"
+   config: "view_control"
 
   9: # Left joystick press
    package: ""

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -12,12 +12,12 @@ axes:
     function: "flipper_back_down"
 
   3: # Right joystick left/right
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "orbit_yaw"
 
   4: # Right joystick up/down
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "orbit_theta"
 
   5: # RT
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"

--- a/hector_gamepad_manager/config/view_control.yaml
+++ b/hector_gamepad_manager/config/view_control.yaml
@@ -37,16 +37,16 @@ buttons:
     function: ""
 
   1: # Button B
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "toggle_tracking"
 
   2: # Button X
     plugin: ""
     function: ""
 
   3: # Button Y
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "activate_2d_mode"
 
   4: # Button LB
     plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
@@ -118,17 +118,17 @@ buttons:
     function: ""
 
   21: # Cross left
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "preset_left"
 
   22: # Cross right
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "preset_right"
 
   23: # Cross up
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "preset_front"
 
   24: # Cross down
-    plugin: ""
-    function: ""
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "preset_back"

--- a/hector_gamepad_manager/config/view_control.yaml
+++ b/hector_gamepad_manager/config/view_control.yaml
@@ -1,0 +1,134 @@
+axes:
+  0: # Left joystick left/right
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "translate_x"
+
+  1: # Left joystick up/down
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "translate_y"
+
+  2: # LT
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "zoom_in"
+
+  3: # Right joystick left/right
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "orbit_yaw"
+
+  4: # Right joystick up/down
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "orbit_theta"
+
+  5: # RT
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "zoom_out"
+
+  6: # Cross left/right
+    plugin: ""
+    function: ""
+
+  7: # Cross up/down
+    plugin: ""
+    function: ""
+
+buttons:
+  0: # Button A
+    plugin: ""
+    function: ""
+
+  1: # Button B
+    plugin: ""
+    function: ""
+
+  2: # Button X
+    plugin: ""
+    function: ""
+
+  3: # Button Y
+    plugin: ""
+    function: ""
+
+  4: # Button LB
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "move_up"
+
+  5: # Button RB
+    plugin: "hector_gamepad_manager_plugins::ViewControlPlugin"
+    function: "move_down"
+
+  6: # Button Back
+    plugin: ""
+    function: ""
+
+  7: # Button Start
+    plugin: ""
+    function: ""
+
+  8: # Button Guide (Manufacturer Button)
+    plugin: ""
+    function: ""
+
+  9: # Left joystick press
+    plugin: ""
+    function: ""
+
+  10: # Right joystick press
+    plugin: ""
+    function: ""
+
+  # -------------------- All the axes can also be used as buttons if specified here --------------------
+  11: # Left joystick left
+    plugin: ""
+    function: ""
+
+  12: # Left joystick right
+    plugin: ""
+    function: ""
+
+  13: # Left joystick up
+    plugin: ""
+    function: ""
+
+  14: # Left joystick down
+    plugin: ""
+    function: ""
+
+  15: # LT
+    plugin: ""
+    function: ""
+
+  16: # Right joystick left
+    plugin: ""
+    function: ""
+
+  17: # Right joystick right
+    plugin: ""
+    function: ""
+
+  18: # Right joystick up
+    plugin: ""
+    function: ""
+
+  19: # Right joystick down
+    plugin: ""
+    function: ""
+
+  20: # RT
+    plugin: ""
+    function: ""
+
+  21: # Cross left
+    plugin: ""
+    function: ""
+
+  22: # Cross right
+    plugin: ""
+    function: ""
+
+  23: # Cross up
+    plugin: ""
+    function: ""
+
+  24: # Cross down
+    plugin: ""
+    function: ""

--- a/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
+++ b/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
@@ -9,6 +9,8 @@ launch:
 - arg:
     name: "ocs_namespace"
     default: "ocs"
+- arg:
+    name: rviz_node_name
 
 - node:
     pkg: "hector_gamepad_manager"
@@ -22,4 +24,6 @@ launch:
         value: "$(var robot_namespace)"
       - name: "ocs_namespace"
         value: "$(var ocs_namespace)"
+      - name: "view_control_plugin.rviz_node_name"
+        value: "$(var rviz_node_name)"
       - from: "$(find-pkg-share hector_gamepad_manager)/config/$(var config_name)_plugin_config.yaml"

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -119,7 +119,7 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
           try {
             std::shared_ptr<GamepadFunctionPlugin> plugin =
                 plugin_loader_.createSharedInstance( plugin_name );
-            plugin->initialize( robot_ns_node_ );
+            plugin->initialize( robot_ns_node_, ocs_ns_node_ );
             plugins_[plugin_name] = plugin;
             RCLCPP_INFO( ocs_ns_node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
           } catch ( const std::exception &e ) {

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -119,7 +119,7 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
           try {
             std::shared_ptr<GamepadFunctionPlugin> plugin =
                 plugin_loader_.createSharedInstance( plugin_name );
-            plugin->initialize( robot_ns_node_, ocs_ns_node_ );
+            plugin->initialize( robot_ns_node_ );
             plugins_[plugin_name] = plugin;
             RCLCPP_INFO( ocs_ns_node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
           } catch ( const std::exception &e ) {
@@ -209,7 +209,7 @@ void HectorGamepadManager::deactivatePlugins()
   for ( const auto &plugin : plugins_ ) {
     if ( plugin.second->isActive() ) {
       plugin.second->deactivate();
-      RCLCPP_INFO( ocs_ns_node_->get_logger(), "Deactivated plugin: %s", plugin.first.c_str() );
+      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Deactivated plugin: %s", plugin.first.c_str() );
     }
   }
   active_plugins_.clear();

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -188,8 +188,8 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &button_mapping : configs_[config_name].button_mappings ) {
     if ( !button_mapping.second.plugin->isActive() ) {
       button_mapping.second.plugin->activate();
-      RCLCPP_INFO( ocs_ns_node_->get_logger(), "Activated plugin: %s",
-                   button_mapping.second.plugin->getPluginName().c_str() );
+      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Activated plugin: %s",
+                    button_mapping.second.plugin->getPluginName().c_str() );
       active_plugins_.push_back( button_mapping.second.plugin );
     }
   }
@@ -197,8 +197,8 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &axis_mapping : configs_[config_name].axis_mappings ) {
     if ( !axis_mapping.second.plugin->isActive() ) {
       axis_mapping.second.plugin->activate();
-      RCLCPP_INFO( ocs_ns_node_->get_logger(), "Activated plugin: %s",
-                   axis_mapping.second.plugin->getPluginName().c_str() );
+      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Activated plugin: %s",
+                    axis_mapping.second.plugin->getPluginName().c_str() );
       active_plugins_.push_back( axis_mapping.second.plugin );
     }
   }

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-
+find_package(eigen3_cmake_module REQUIRED)
 # Define a list of dependencies in alphabetical order
 set(DEPENDENCIES
     controller_manager_msgs
@@ -27,7 +27,9 @@ set(DEPENDENCIES
     rclcpp_action
     sensor_msgs
     srdfdom
-    std_srvs)
+    std_srvs
+    hector_rviz_plugins_msgs
+    Eigen3)
 
 foreach(dependency IN LISTS DEPENDENCIES)
   find_package(${dependency} REQUIRED)
@@ -38,11 +40,12 @@ set(HEADERS
     include/hector_gamepad_manager_plugins/flipper_plugin.hpp
     include/hector_gamepad_manager_plugins/controller_helper.hpp
     include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+    include/hector_gamepad_manager_plugins/view_control_plugin.hpp
     include/hector_gamepad_manager_plugins/moveit_plugin.hpp)
 
 set(SOURCES
     src/drive_plugin.cpp src/manipulation_plugin.cpp src/flipper_plugin.cpp
-    src/controller_helper.cpp src/moveit_plugin.cpp)
+    src/controller_helper.cpp src/moveit_plugin.cpp src/view_control_plugin.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 target_include_directories(

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
@@ -10,7 +10,7 @@ namespace hector_gamepad_manager_plugins
 class DrivePlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
@@ -10,7 +10,7 @@ namespace hector_gamepad_manager_plugins
 class DrivePlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -12,7 +12,7 @@ namespace hector_gamepad_manager_plugins
 class FlipperPlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -12,7 +12,7 @@ namespace hector_gamepad_manager_plugins
 class FlipperPlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
@@ -16,7 +16,7 @@ namespace hector_gamepad_manager_plugins
 class ManipulationPlugin final : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
@@ -16,7 +16,7 @@ namespace hector_gamepad_manager_plugins
 class ManipulationPlugin final : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/moveit_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/moveit_plugin.hpp
@@ -18,7 +18,7 @@ namespace hector_gamepad_manager_plugins
 class MoveitPlugin final : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/moveit_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/moveit_plugin.hpp
@@ -18,7 +18,7 @@ namespace hector_gamepad_manager_plugins
 class MoveitPlugin final : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
-  void initialize( const rclcpp::Node::SharedPtr &node ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
 
   std::string getPluginName() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
@@ -21,6 +21,13 @@ namespace hector_gamepad_manager_plugins
 class ViewControlPlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {
 public:
+  enum PresetDirection {
+    FRONT = 0,
+    BACK = 1,
+    LEFT = 2,
+    RIGHT = 3,
+    NONE = 4,
+  };
   using MoveEye = hector_rviz_plugins_msgs::srv::MoveEye;
   using MoveEyeAndFocus = hector_rviz_plugins_msgs::srv::MoveEyeAndFocus;
   using SetViewMode = hector_rviz_plugins_msgs::srv::SetViewMode;
@@ -46,17 +53,29 @@ public:
 private:
   rclcpp::Publisher<hector_rviz_plugins_msgs::msg::RelativeViewControllerCmd>::SharedPtr view_controller_pub_;
   hector_rviz_plugins_msgs::msg::RelativeViewControllerCmd rviz_cmd_msg;
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::MoveEyeAndFocus>::SharedPtr move_eye_and_focus_client_;
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::TrackFrame>::SharedPtr track_frame_client_;
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::SetViewMode>::SharedPtr set_view_mode_client_;
 
   /* runtime state -------------------------------------------------------- */
-  bool stop_tracking_{ false };
+  bool tracking_active_{ false };
   bool switch_to_3d_mode_{ true };
   bool disable_animation_{ true };
+
+  bool activate_tracking_{ false }; // request to activate tracking
+  bool activate_2d_mode_{ false };
+
+  PresetDirection preset_direction_{ PresetDirection::FRONT };
 
   /* tunable speeds ------------------------------------------------------- */
   double orbit_speed_{ 1.5 };     ///< rad/s
   double zoom_speed_{ 2.0 };      ///< m/s
   double translate_speed_{ 1.0 }; ///< m/s
-  double preset_distance_{ 4.0 }; ///< m (distance from base_link in presets)
+  double preset_distance_{ 2.0 }; ///< m (distance from base_link in presets)
+  double preset_eye_height_{ 1.5 };
+  double preset_focus_height_{ 0.25 };
+  std::string tracked_frame_;
+  bool interacted_{ false };
 };
 } // namespace hector_gamepad_manager_plugins
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
@@ -26,7 +26,8 @@ public:
   using TrackFrame = hector_rviz_plugins_msgs::srv::TrackFrame;
   using Point = geometry_msgs::msg::Point;
   /* Game‑pad plugin API -------------------------------------------------- */
-  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns,
+                   const rclcpp::Node::SharedPtr &node_operator_ns ) override;
   std::string getPluginName() override { return "view_control_plugin"; }
 
   void handleAxis( const std::string &function, double value ) override;
@@ -56,7 +57,7 @@ private:
   bool tracking_on_{ false };
 
   Eigen::Vector3d eye_{ 0, 0, 3 }; ///< eye‑focus vector (world)
-  Eigen::Vector3d focus{0,0,0};
+  Eigen::Vector3d focus{ 0, 0, 0 };
   geometry_msgs::msg::Point focus_point_{}; ///< world‑frame focus
 
   /* live axis values ----------------------------------------------------- */
@@ -76,7 +77,7 @@ private:
 
   /* hacks ------------------------------------------------------- */
   int skip_x_ = 3;
-  int counter_ =0;
+  int counter_ = 0;
 };
 } // namespace hector_gamepad_manager_plugins
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
@@ -34,13 +34,11 @@ public:
   using TrackFrame = hector_rviz_plugins_msgs::srv::TrackFrame;
   using Point = geometry_msgs::msg::Point;
   /* Game‑pad plugin API -------------------------------------------------- */
-  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns,
-                   const rclcpp::Node::SharedPtr &node_operator_ns ) override;
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns ) override;
   std::string getPluginName() override { return "view_control_plugin"; }
 
   void handleAxis( const std::string &function, double value ) override;
   void handlePress( const std::string &function ) override;
-  void handleRelease( const std::string &function ) override;
   void handleHold( const std::string &function ) override;
 
   /* no special per‑frame “hold” handling; defaults inherited */

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/view_control_plugin.hpp
@@ -1,0 +1,83 @@
+//
+// Created by aljoscha-schmidt on 7/13/25.
+//
+
+#ifndef VIEWER_PLUGIN_HPP
+#define VIEWER_PLUGIN_HPP
+
+#include <hector_rviz_plugins_msgs/srv/move_eye.hpp>
+#include <hector_rviz_plugins_msgs/srv/move_eye_and_focus.hpp>
+#include <hector_rviz_plugins_msgs/srv/set_view_mode.hpp>
+#include <hector_rviz_plugins_msgs/srv/track_frame.hpp>
+
+#include <Eigen/Geometry>
+#include <geometry_msgs/msg/point.hpp>
+#include <hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp>
+
+namespace hector_gamepad_manager_plugins
+{
+
+class ViewControlPlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
+{
+public:
+  using MoveEye = hector_rviz_plugins_msgs::srv::MoveEye;
+  using MoveEyeAndFocus = hector_rviz_plugins_msgs::srv::MoveEyeAndFocus;
+  using SetViewMode = hector_rviz_plugins_msgs::srv::SetViewMode;
+  using TrackFrame = hector_rviz_plugins_msgs::srv::TrackFrame;
+  using Point = geometry_msgs::msg::Point;
+  /* Game‑pad plugin API -------------------------------------------------- */
+  void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  ) override;
+  std::string getPluginName() override { return "view_control_plugin"; }
+
+  void handleAxis( const std::string &function, double value ) override;
+  void handlePress( const std::string &function ) override;
+  void handleRelease( const std::string &function ) override;
+
+  /* no special per‑frame “hold” handling; defaults inherited */
+
+  void update() override;
+  void activate() override { active_ = true; }
+  void deactivate() override;
+
+private:
+  /* helper methods ------------------------------------------------------- */
+  bool waitForServicesOnce();
+  void translateWorld( const Eigen::Vector3d &delta_world );
+  void orbit( double d_yaw, double d_pitch );
+
+  /* service clients ------------------------------------------------------ */
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::MoveEye>::SharedPtr move_eye_cli_;
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::MoveEyeAndFocus>::SharedPtr move_eye_focus_cli_;
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::SetViewMode>::SharedPtr mode_cli_;
+  rclcpp::Client<hector_rviz_plugins_msgs::srv::TrackFrame>::SharedPtr track_cli_;
+
+  /* runtime state -------------------------------------------------------- */
+  bool services_ready_{ false };
+  bool tracking_on_{ false };
+
+  Eigen::Vector3d eye_{ 0, 0, 3 }; ///< eye‑focus vector (world)
+  Eigen::Vector3d focus{0,0,0};
+  geometry_msgs::msg::Point focus_point_{}; ///< world‑frame focus
+
+  /* live axis values ----------------------------------------------------- */
+  double orbit_yaw_{ 0.0 };
+  double orbit_theta_{ 0.0 };
+  double translate_x_{ 0.0 };
+  double translate_y_{ 0.0 };
+  double zoom_in_{ 0.0 };
+  double zoom_out_{ 0.0 };
+  int move_z_dir_{ 0 }; ///< +1 up, –1 down, 0 idle
+
+  /* tunable speeds ------------------------------------------------------- */
+  double orbit_speed_{ 1.5 };     ///< rad/s
+  double zoom_speed_{ 2.0 };      ///< m/s
+  double translate_speed_{ 1.0 }; ///< m/s
+  double preset_distance_{ 4.0 }; ///< m (distance from base_link in presets)
+
+  /* hacks ------------------------------------------------------- */
+  int skip_x_ = 3;
+  int counter_ =0;
+};
+} // namespace hector_gamepad_manager_plugins
+
+#endif // VIEWER_PLUGIN_HPP

--- a/hector_gamepad_manager_plugins/package.xml
+++ b/hector_gamepad_manager_plugins/package.xml
@@ -21,6 +21,8 @@
   <depend>sensor_msgs</depend>
   <depend>srdfdom</depend>
   <depend>std_srvs</depend>
+  <depend>hector_rviz_plugins_msgs</depend>
+  <depend>eigen</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/hector_gamepad_manager_plugins/plugins.xml
+++ b/hector_gamepad_manager_plugins/plugins.xml
@@ -12,4 +12,7 @@
     <class type="hector_gamepad_manager_plugins::MoveitPlugin" base_class_type="hector_gamepad_plugin_interface::GamepadFunctionPlugin">
         <description>Interface to moveit planners.</description>
     </class>
+    <class type="hector_gamepad_manager_plugins::ViewControlPlugin" base_class_type="hector_gamepad_plugin_interface::GamepadFunctionPlugin">
+        <description>Interface to control the hector rviz view controller.</description>
+    </class>
 </library>

--- a/hector_gamepad_manager_plugins/src/drive_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/drive_plugin.cpp
@@ -3,31 +3,31 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void DrivePlugin::initialize( const rclcpp::Node::SharedPtr &node )
+void DrivePlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
 {
-  node_ = node;
+  node_ = node_robot_ns;
   const std::string plugin_namespace = getPluginName();
 
   max_linear_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_linear_speed", std::ref( max_linear_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_linear_speed", std::ref( max_linear_speed_ ),
       "Maximum linear speed in m/s in Normal Mode.",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
 
   max_angular_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_angular_speed", std::ref( max_angular_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_angular_speed", std::ref( max_angular_speed_ ),
       "Maximum angular speed in rad/s in Normal Mode.",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
 
   slow_factor_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".slow_factor", std::ref( slow_factor_ ),
+      node_robot_ns, plugin_namespace + ".slow_factor", std::ref( slow_factor_ ),
       "Scaling factor for speed in Slow Mode.",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0 && value < 1.0; } ) );
 
   fast_factor_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".fast_factor", std::ref( fast_factor_ ),
+      node_robot_ns, plugin_namespace + ".fast_factor", std::ref( fast_factor_ ),
       "Scaling factor for speed in Fast Mode.",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value >= 1.0; } ) );

--- a/hector_gamepad_manager_plugins/src/drive_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/drive_plugin.cpp
@@ -3,7 +3,7 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void DrivePlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
+void DrivePlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns )
 {
   node_ = node_robot_ns;
   const std::string plugin_namespace = getPluginName();

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -3,7 +3,7 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
+void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns )
 {
   node_ = node_robot_ns;
   const std::string plugin_namespace = getPluginName();

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -3,23 +3,23 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
+void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
 {
-  node_ = node;
+  node_ = node_robot_ns;
   const std::string plugin_namespace = getPluginName();
 
   // Setup reconfigurable Parameters
   speed_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".speed", std::ref( speed_ ), "Flipper Speed",
+      node_robot_ns, plugin_namespace + ".speed", std::ref( speed_ ), "Flipper Speed",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   flipper_front_factor_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".flipper_front_factor", std::ref( flipper_front_factor_ ),
+      node_robot_ns, plugin_namespace + ".flipper_front_factor", std::ref( flipper_front_factor_ ),
       "Flipper Front Factor", hector::ParameterOptions<double>().onValidate( []( const auto &value ) {
         return value > 0.0;
       } ) );
   flipper_back_factor_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".flipper_back_factor", std::ref( flipper_back_factor_ ),
+      node_robot_ns, plugin_namespace + ".flipper_back_factor", std::ref( flipper_back_factor_ ),
       "Flipper Back Factor", hector::ParameterOptions<double>().onValidate( []( const auto &value ) {
         return value > 0.0;
       } ) );
@@ -45,7 +45,7 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
       "/" + node_->get_parameter( "robot_namespace" ).as_string() + "/" + command_topic, 10 );
 
-  controller_helper_.initialize( node, plugin_namespace );
+  controller_helper_.initialize( node_robot_ns, plugin_namespace );
   active_ = true;
 }
 

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -3,39 +3,39 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node )
+void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
 {
-  node_ = node;
+  node_ = node_robot_ns;
   const auto plugin_namespace = getPluginName();
 
   // Setup reconfigurable parameters
   max_eef_linear_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_eef_linear_speed", std::ref( max_eef_linear_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_eef_linear_speed", std::ref( max_eef_linear_speed_ ),
       "Maximum Linear Speed of the End Effector",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_eef_angular_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_eef_angular_speed", std::ref( max_eef_angular_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_eef_angular_speed", std::ref( max_eef_angular_speed_ ),
       "Maximum Angular Speed of the End Effector",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_gripper_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_gripper_speed", std::ref( max_gripper_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_gripper_speed", std::ref( max_gripper_speed_ ),
       "Maximum Speed of the Gripper",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_drive_linear_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_drive_linear_speed", std::ref( max_drive_linear_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_drive_linear_speed", std::ref( max_drive_linear_speed_ ),
       "Maximum Linear Speed of the Base",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_drive_angular_speed_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".max_drive_angular_speed", std::ref( max_drive_angular_speed_ ),
+      node_robot_ns, plugin_namespace + ".max_drive_angular_speed", std::ref( max_drive_angular_speed_ ),
       "Maximum Angular Speed of the Base",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   eef_twist_frame_param_sub_ = hector::createReconfigurableParameter(
-      node, plugin_namespace + ".eef_twist_frame", std::ref( eef_cmd_.header.frame_id ),
+      node_robot_ns, plugin_namespace + ".eef_twist_frame", std::ref( eef_cmd_.header.frame_id ),
       "Frame of the End Effector Twist",
       hector::ParameterOptions<std::string>().onValidate(
           []( const auto &value ) { return !value.empty(); } ) );
@@ -58,7 +58,7 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node )
       twist_controller_name_ + "/gripper_vel_cmd", 10 );
   hold_mode_client_ =
       node_->create_client<std_srvs::srv::SetBool>( twist_controller_name_ + "/hold_mode" );
-  controller_helper_.initialize( node, plugin_namespace );
+  controller_helper_.initialize( node_robot_ns, plugin_namespace );
 }
 
 std::string ManipulationPlugin::getPluginName() { return "manipulation_plugin"; }

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -3,7 +3,7 @@
 namespace hector_gamepad_manager_plugins
 {
 
-void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
+void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns )
 {
   node_ = node_robot_ns;
   const auto plugin_namespace = getPluginName();
@@ -15,8 +15,8 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_n
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_eef_angular_speed_param_sub_ = hector::createReconfigurableParameter(
-      node_robot_ns, plugin_namespace + ".max_eef_angular_speed", std::ref( max_eef_angular_speed_ ),
-      "Maximum Angular Speed of the End Effector",
+      node_robot_ns, plugin_namespace + ".max_eef_angular_speed",
+      std::ref( max_eef_angular_speed_ ), "Maximum Angular Speed of the End Effector",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_gripper_speed_param_sub_ = hector::createReconfigurableParameter(
@@ -25,13 +25,13 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_n
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_drive_linear_speed_param_sub_ = hector::createReconfigurableParameter(
-      node_robot_ns, plugin_namespace + ".max_drive_linear_speed", std::ref( max_drive_linear_speed_ ),
-      "Maximum Linear Speed of the Base",
+      node_robot_ns, plugin_namespace + ".max_drive_linear_speed",
+      std::ref( max_drive_linear_speed_ ), "Maximum Linear Speed of the Base",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   max_drive_angular_speed_param_sub_ = hector::createReconfigurableParameter(
-      node_robot_ns, plugin_namespace + ".max_drive_angular_speed", std::ref( max_drive_angular_speed_ ),
-      "Maximum Angular Speed of the Base",
+      node_robot_ns, plugin_namespace + ".max_drive_angular_speed",
+      std::ref( max_drive_angular_speed_ ), "Maximum Angular Speed of the Base",
       hector::ParameterOptions<double>().onValidate(
           []( const auto &value ) { return value > 0.0; } ) );
   eef_twist_frame_param_sub_ = hector::createReconfigurableParameter(

--- a/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
@@ -9,7 +9,7 @@
 
 namespace hector_gamepad_manager_plugins
 {
-void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
+void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns )
 {
   node_ = node_robot_ns;
   const std::string plugin_name = getPluginName();

--- a/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
@@ -9,9 +9,9 @@
 
 namespace hector_gamepad_manager_plugins
 {
-void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node )
+void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns  )
 {
-  node_ = node;
+  node_ = node_robot_ns;
   const std::string plugin_name = getPluginName();
   node_->declare_parameter<std::vector<std::string>>( plugin_name + ".start_controllers" );
   node_->declare_parameter<std::vector<std::string>>( plugin_name + ".stop_controllers" );
@@ -52,7 +52,7 @@ void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node )
         robot_description_semantic_ = msg->data;
         robot_description_semantic_subscriber_.reset();
       } );
-  controller_helper_.initialize( node, plugin_name );
+  controller_helper_.initialize( node_robot_ns, plugin_name );
   joint_state_subscriber_ = node_->create_subscription<sensor_msgs::msg::JointState>(
       "joint_states", 10,
       [this]( const sensor_msgs::msg::JointState::SharedPtr msg ) { joint_state_ = *msg; } );

--- a/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
@@ -11,72 +11,54 @@ namespace hector_gamepad_manager_plugins
 void ViewControlPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns,
                                     const rclcpp::Node::SharedPtr &node_operator_ns )
 {
-  node_ = node_operator_ns;
+  node_ = node_robot_ns;
 
   std::string rviz_node_name =
       node_->declare_parameter<std::string>( getPluginName() + ".rviz_node_name", "" );
 
   RCLCPP_WARN_STREAM( node_->get_logger(), getPluginName() << ".rviz_node_name: " << rviz_node_name );
-  move_eye_cli_ =
-      node_->create_client<MoveEye>( rviz_node_name + "/hector_view_controller/move_eye" );
-  move_eye_focus_cli_ = node_->create_client<MoveEyeAndFocus>(
-      rviz_node_name + "/hector_view_controller/move_eye_and_focus" );
-  mode_cli_ =
-      node_->create_client<SetViewMode>( rviz_node_name + "/hector_view_controller/set_view_mode" );
-  track_cli_ = node_->create_client<TrackFrame>( rviz_node_name +
-                                                 "/hector_view_controller/set_tracked_frame" );
 
+  view_controller_pub_ =
+      node_->create_publisher<hector_rviz_plugins_msgs::msg::RelativeViewControllerCmd>(
+          rviz_node_name + "/hector_view_controller/relative_cmds", 10 );
   /* speed parameters */
-  node_->declare_parameter( getPluginName() + ".orbit_speed", orbit_speed_ );
-  node_->declare_parameter( getPluginName() + ".zoom_speed", zoom_speed_ );
-  node_->declare_parameter( getPluginName() + ".translate_speed", translate_speed_ );
-  node_->get_parameter( getPluginName() + ".orbit_speed", orbit_speed_ );
-  node_->get_parameter( getPluginName() + ".zoom_speed", zoom_speed_ );
-  node_->get_parameter( getPluginName() + ".translate_speed", translate_speed_ );
+  orbit_speed_ = node_->declare_parameter( getPluginName() + ".orbit_speed", 0.1 );
+  zoom_speed_ = node_->declare_parameter( getPluginName() + ".zoom_speed", 0.1 );
+  translate_speed_ = node_->declare_parameter( getPluginName() + ".translate_speed", 0.1 );
+
+  reset();
 }
 
 /* ------------------------------ input ------------------------------ */
 void ViewControlPlugin::handleAxis( const std::string &f, double v )
 {
   if ( f == "orbit_yaw" )
-    orbit_yaw_ = v;
+    rviz_cmd_msg.yaw_delta = v * orbit_speed_;
   else if ( f == "orbit_theta" )
-    orbit_theta_ = v;
+    rviz_cmd_msg.theta_delta = v * orbit_speed_;
   else if ( f == "translate_x" )
-    translate_x_ = v;
+    rviz_cmd_msg.translation.x = v * translate_speed_;
   else if ( f == "translate_y" )
-    translate_y_ = v;
+    rviz_cmd_msg.translation.y = v * translate_speed_;
   else if ( f == "zoom_in" )
-    zoom_in_ = v; //  0…+1
+    rviz_cmd_msg.zoom_factor -= v * zoom_speed_; //  0…+1
   else if ( f == "zoom_out" )
-    zoom_out_ = v; //  0…+1
+    rviz_cmd_msg.zoom_factor += v * zoom_speed_; //  0…+1
 }
 
 void ViewControlPlugin::handlePress( const std::string &f )
 {
-  if ( f == "move_up" )
-    move_z_dir_ = +1;
-  else if ( f == "move_down" )
-    move_z_dir_ = -1;
-  else if ( f == "mode_2d" || f == "mode_3d" ) {
-    auto req = std::make_shared<SetViewMode::Request>();
-    req->mode.mode = ( f == "mode_2d" ) ? hector_rviz_plugins_msgs::msg::ViewMode::MODE_2D
-                                        : hector_rviz_plugins_msgs::msg::ViewMode::MODE_3D;
-    mode_cli_->async_send_request( req );
+  if ( f == "mode_2d" || f == "mode_3d" ) {
+    rviz_cmd_msg.switch_to_3d_mode = ( f == "mode_3d" );
   } else if ( f == "track_base" ) {
-    auto req = std::make_shared<TrackFrame::Request>();
-    req->frame = "base_link";
-    track_cli_->async_send_request( req );
-    tracking_on_ = true;
+    rviz_cmd_msg.stop_tracking = false;
   } else if ( f == "untrack" ) {
-    auto req = std::make_shared<TrackFrame::Request>();
-    req->frame = "";
-    track_cli_->async_send_request( req );
-    tracking_on_ = false;
+    rviz_cmd_msg.stop_tracking = true;
   }
   /* ------ presets (base_link frame) -------------------------------- */
   else if ( f.rfind( "preset_", 0 ) == 0 ) {
-    const double d = preset_distance_;
+    RCLCPP_WARN_STREAM( node_->get_logger(), "Presetting " << f << " Not yet implemented" );
+    /*const double d = preset_distance_;
     Point eye, focus;
     focus.x = focus.y = focus.z = 0.0; // origin in base_link
 
@@ -96,115 +78,43 @@ void ViewControlPlugin::handlePress( const std::string &f )
     req->focus = focus;
     move_eye_focus_cli_->async_send_request( req );
 
-    orbit_vector_ = Eigen::Vector3d( eye.x, eye.y, eye.z );
-    focus_point_ = focus;
+    focus_point_ = focus;*/
   }
 }
 
-void ViewControlPlugin::handleRelease( const std::string &f )
+void ViewControlPlugin::handleHold( const std::string &function )
 {
-  if ( f == "move_up" || f == "move_down" )
-    move_z_dir_ = 0;
+  RCLCPP_INFO( node_->get_logger(), "Hadle hold for function %s", function.c_str() );
+  if ( function == "move_up" )
+    rviz_cmd_msg.translation.z = 0.5 * translate_speed_;
+  else if ( function == "move_down" )
+    rviz_cmd_msg.translation.z = -0.5 * translate_speed_;
 }
+
+void ViewControlPlugin::handleRelease( const std::string &f ) { }
 
 /* ----------------------------- update ------------------------------ */
 void ViewControlPlugin::update()
 {
   if ( !active_ )
     return;
-  if ( skip_x_ > counter_ ) {
-    counter_++;
-    return; // skip some frames to avoid flooding the service calls
-  }
-  RCLCPP_INFO_STREAM( node_->get_logger(),
-                      "ViewControlPlugin::update(): orbit_yaw_ = "
-                          << orbit_yaw_ << ", orbit_theta_ = " << orbit_theta_
-                          << ", translate_x_ = " << translate_x_
-                          << ", translate_y_ = " << translate_y_ << ", zoom_in_ = " << zoom_in_
-                          << ", zoom_out_ = " << zoom_out_ << ", move_z_dir_ = " << move_z_dir_ );
-  const double dt = 1.0 / 60.0;
-
-  /* ------ zoom ----------------------------------------------------- */
-  /*double zoom_vel = ( zoom_in_ - zoom_out_ ) * zoom_speed_; // in m/s
-  if ( std::fabs( zoom_vel ) > 1e-3 ) {
-    Eigen::Vector3d dz = orbit_vector_.normalized() * zoom_vel * dt;
-    translateWorld( dz );
-  }
-
-  /* ------ translate XY / Z ---------------------------------------- #1#
-  if ( std::fabs( translate_x_ ) > 1e-3 || std::fabs( translate_y_ ) > 1e-3 || move_z_dir_ != 0 ) {
-    Eigen::Vector3d x_axis( 1, 0, 0 ), y_axis( 0, 1, 0 ), z_axis( 0, 0, 1 );
-    Eigen::Vector3d d = ( x_axis * -translate_x_   // left/right
-                          + y_axis * translate_y_  // forward/back in world Y
-                          + z_axis * move_z_dir_ ) // up/down
-                        * translate_speed_ * dt;
-    translateWorld( d );
-  }*/
-
-  /* ------ orbit ---------------------------------------------------- */
-  if ( std::fabs( orbit_yaw_ ) > 1e-3 || std::fabs( orbit_theta_ ) > 1e-3 ) {
-    orbit( orbit_yaw_ * orbit_speed_ * dt, orbit_theta_ * orbit_speed_ * dt );
-  }
-}
-
-/* --------------------------- helpers ------------------------------- */
-bool ViewControlPlugin::waitForServicesOnce()
-{
-  return true;
-  const auto t = std::chrono::seconds( 0 );
-  return move_eye_cli_->wait_for_service( t ) && move_eye_focus_cli_->wait_for_service( t ) &&
-         mode_cli_->wait_for_service( t ) && track_cli_->wait_for_service( t );
-}
-
-void ViewControlPlugin::translateWorld( const Eigen::Vector3d &d )
-{
-  focus_point_.x += d.x();
-  focus_point_.y += d.y();
-  focus_point_.z += d.z();
-  orbit_vector_ += d;
-
-  Point eye;
-  eye.x = focus_point_.x + orbit_vector_.x();
-  eye.y = focus_point_.y + orbit_vector_.y();
-  eye.z = focus_point_.z + orbit_vector_.z();
-
-  auto req = std::make_shared<MoveEye::Request>();
-  req->header.frame_id = "world";
-  req->eye = eye;
-  req->stop_tracking = !tracking_on_;
-  move_eye_cli_->async_send_request( req );
-}
-
-void ViewControlPlugin::orbit( double d_yaw, double d_pitch )
-{
-  Eigen::AngleAxisd yaw( d_yaw, Eigen::Vector3d::UnitZ() );
-  Eigen::Vector3d axis_x = Eigen::Vector3d::UnitZ().cross( eye ).normalized();
-  Eigen::AngleAxisd pitch( d_pitch, axis_x );
-
-  orbit_vector_ = yaw * pitch * orbit_vector_;
-
-  Point eye;
-  eye.x = focus_point_.x + orbit_vector_.x();
-  eye.y = focus_point_.y + orbit_vector_.y();
-  eye.z = focus_point_.z + orbit_vector_.z();
-
-  auto req = std::make_shared<MoveEye::Request>();
-  req->header.frame_id = "world";
-  req->eye = eye;
-  req->stop_tracking = !tracking_on_;
-  move_eye_cli_->async_send_request( req );
+  view_controller_pub_->publish( rviz_cmd_msg );
+  reset();
 }
 
 void ViewControlPlugin::deactivate()
 {
   active_ = false;
-
-  /* reset all live inputs so we don't send stale commands when
-     the plugin is re‑activated later */
-  orbit_yaw_ = orbit_theta_ = 0.0;
-  translate_x_ = translate_y_ = 0.0;
-  zoom_in_ = zoom_out_ = 0.0;
-  move_z_dir_ = 0;
+  reset();
+}
+void ViewControlPlugin::reset()
+{
+  // Reset cmds
+  rviz_cmd_msg = hector_rviz_plugins_msgs::msg::RelativeViewControllerCmd();
+  rviz_cmd_msg.zoom_factor = 1.0;
+  rviz_cmd_msg.disable_animation = true;
+  rviz_cmd_msg.stop_tracking = true;
+  rviz_cmd_msg.switch_to_3d_mode = true;
 }
 
 /* ----------------------- plugin export ----------------------------- */

--- a/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
@@ -8,8 +8,7 @@ namespace hector_gamepad_manager_plugins
 {
 
 /* --------------------------- initialisation ------------------------ */
-void ViewControlPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns,
-                                    const rclcpp::Node::SharedPtr &node_operator_ns )
+void ViewControlPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns )
 {
   node_ = node_robot_ns;
 
@@ -95,8 +94,6 @@ void ViewControlPlugin::handleHold( const std::string &function )
     rviz_cmd_msg.translation.z = -0.5 * translate_speed_;
   interacted_ = true;
 }
-
-void ViewControlPlugin::handleRelease( const std::string &f ) { }
 
 /* ----------------------------- update ------------------------------ */
 void ViewControlPlugin::update()

--- a/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
@@ -21,11 +21,21 @@ void ViewControlPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns
   view_controller_pub_ =
       node_->create_publisher<hector_rviz_plugins_msgs::msg::RelativeViewControllerCmd>(
           rviz_node_name + "/hector_view_controller/relative_cmds", 10 );
+  move_eye_and_focus_client_ = node_->create_client<hector_rviz_plugins_msgs::srv::MoveEyeAndFocus>(
+      rviz_node_name + "/hector_view_controller/move_eye_and_focus" );
+  track_frame_client_ = node_->create_client<hector_rviz_plugins_msgs::srv::TrackFrame>(
+      rviz_node_name + "/hector_view_controller/set_tracked_frame" );
   /* speed parameters */
   orbit_speed_ = node_->declare_parameter( getPluginName() + ".orbit_speed", 0.1 );
   zoom_speed_ = node_->declare_parameter( getPluginName() + ".zoom_speed", 0.1 );
   translate_speed_ = node_->declare_parameter( getPluginName() + ".translate_speed", 0.1 );
-
+  set_view_mode_client_ = node_->create_client<hector_rviz_plugins_msgs::srv::SetViewMode>(
+      rviz_node_name + "/hector_view_controller/set_view_mode" );
+  tracked_frame_ =
+      node_->declare_parameter( getPluginName() + ".tracked_frame", std::string( "base_link" ) );
+  preset_distance_ = node_->declare_parameter( getPluginName() + ".preset_direction", 2.2 );
+  preset_eye_height_ = node_->declare_parameter( getPluginName() + ".preset_eye_height", 0.25 );
+  preset_focus_height_ = node_->declare_parameter( getPluginName() + ".preset_focus_height", 0.55 );
   reset();
 }
 
@@ -44,6 +54,7 @@ void ViewControlPlugin::handleAxis( const std::string &f, double v )
     rviz_cmd_msg.zoom_factor -= v * zoom_speed_; //  0…+1
   else if ( f == "zoom_out" )
     rviz_cmd_msg.zoom_factor += v * zoom_speed_; //  0…+1
+  interacted_ = true;
 }
 
 void ViewControlPlugin::handlePress( const std::string &f )
@@ -57,38 +68,32 @@ void ViewControlPlugin::handlePress( const std::string &f )
   }
   /* ------ presets (base_link frame) -------------------------------- */
   else if ( f.rfind( "preset_", 0 ) == 0 ) {
-    RCLCPP_WARN_STREAM( node_->get_logger(), "Presetting " << f << " Not yet implemented" );
-    /*const double d = preset_distance_;
-    Point eye, focus;
-    focus.x = focus.y = focus.z = 0.0; // origin in base_link
-
     if ( f == "preset_front" ) {
-      eye.x = +d;
+      preset_direction_ = PresetDirection::FRONT;
     } else if ( f == "preset_back" ) {
-      eye.x = -d;
+      preset_direction_ = PresetDirection::BACK;
     } else if ( f == "preset_left" ) {
-      eye.y = +d;
+      preset_direction_ = PresetDirection::LEFT;
     } else if ( f == "preset_right" ) {
-      eye.y = -d;
+      preset_direction_ = PresetDirection::RIGHT;
     }
-
-    auto req = std::make_shared<MoveEyeAndFocus::Request>();
-    req->header.frame_id = "base_link";
-    req->eye = eye;
-    req->focus = focus;
-    move_eye_focus_cli_->async_send_request( req );
-
-    focus_point_ = focus;*/
+  } else if ( f == "toggle_tracking" ) {
+    tracking_active_ = !tracking_active_;
+    if ( tracking_active_ )
+      activate_tracking_ = true;
+  } else if ( f == "activate_2d_mode" ) {
+    activate_2d_mode_ = true;
   }
+  interacted_ = true;
 }
 
 void ViewControlPlugin::handleHold( const std::string &function )
 {
-  RCLCPP_INFO( node_->get_logger(), "Hadle hold for function %s", function.c_str() );
   if ( function == "move_up" )
     rviz_cmd_msg.translation.z = 0.5 * translate_speed_;
   else if ( function == "move_down" )
     rviz_cmd_msg.translation.z = -0.5 * translate_speed_;
+  interacted_ = true;
 }
 
 void ViewControlPlugin::handleRelease( const std::string &f ) { }
@@ -98,7 +103,62 @@ void ViewControlPlugin::update()
 {
   if ( !active_ )
     return;
-  view_controller_pub_->publish( rviz_cmd_msg );
+  // ******** Activate Tracking *******************************************
+  if ( activate_tracking_ || preset_direction_ != PresetDirection::NONE ) {
+    RCLCPP_INFO( node_->get_logger(), "Activating tracking for frame %s", tracked_frame_.c_str() );
+    const auto req = std::make_shared<hector_rviz_plugins_msgs::srv::TrackFrame::Request>();
+    req->frame = tracked_frame_;
+    if ( track_frame_client_->wait_for_service( std::chrono::milliseconds( 50 ) ) )
+      track_frame_client_->async_send_request( req );
+    else
+      RCLCPP_ERROR( node_->get_logger(), "Service %s not available",
+                    track_frame_client_->get_service_name() );
+    activate_tracking_ = false;
+  }
+  // ******** Preset Directions *******************************************
+  if ( preset_direction_ == PresetDirection::NONE && interacted_ ) {
+    view_controller_pub_->publish( rviz_cmd_msg );
+  } else {
+    const auto req = std::make_shared<hector_rviz_plugins_msgs::srv::MoveEyeAndFocus::Request>();
+    req->header.frame_id = tracked_frame_;
+    switch ( preset_direction_ ) {
+    case PresetDirection::FRONT:
+      req->eye.x = -preset_distance_;
+      break;
+    case PresetDirection::BACK:
+      req->eye.x = preset_distance_;
+      break;
+    case PresetDirection::LEFT:
+      req->eye.y = -preset_distance_;
+      break;
+    case PresetDirection::RIGHT:
+      req->eye.y = preset_distance_;
+      break;
+    default:
+      req->eye.x = -preset_distance_;
+    }
+    req->eye.z = preset_eye_height_;
+    req->focus.z = preset_focus_height_;
+    req->disable_animation = true;
+    req->stop_tracking = !tracking_active_;
+    if ( move_eye_and_focus_client_->wait_for_service( std::chrono::milliseconds( 50 ) ) )
+      move_eye_and_focus_client_->async_send_request( req );
+    else
+      RCLCPP_WARN( node_->get_logger(), "Service %s not available",
+                   move_eye_and_focus_client_->get_service_name() );
+  }
+  // ******** 2D MODE ********************************************************
+  if ( activate_2d_mode_ ) {
+    const auto req = std::make_shared<hector_rviz_plugins_msgs::srv::SetViewMode::Request>();
+    req->mode.mode = 1;
+    req->disable_animation = true;
+    if ( set_view_mode_client_->wait_for_service( std::chrono::milliseconds( 50 ) ) )
+      set_view_mode_client_->async_send_request( req );
+    else
+      RCLCPP_WARN( node_->get_logger(), "Service %s not available",
+                   move_eye_and_focus_client_->get_service_name() );
+  }
+
   reset();
 }
 
@@ -113,8 +173,11 @@ void ViewControlPlugin::reset()
   rviz_cmd_msg = hector_rviz_plugins_msgs::msg::RelativeViewControllerCmd();
   rviz_cmd_msg.zoom_factor = 1.0;
   rviz_cmd_msg.disable_animation = true;
-  rviz_cmd_msg.stop_tracking = true;
+  rviz_cmd_msg.stop_tracking = !tracking_active_;
   rviz_cmd_msg.switch_to_3d_mode = true;
+  preset_direction_ = PresetDirection::NONE;
+  interacted_ = false;
+  activate_2d_mode_ = false;
 }
 
 /* ----------------------- plugin export ----------------------------- */

--- a/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
@@ -116,13 +116,12 @@ void ViewControlPlugin::update()
     counter_++;
     return; // skip some frames to avoid flooding the service calls
   }
-  RCLCPP_INFO_STREAM( node_->get_logger(), "ViewControlPlugin::update(): orbit_yaw_ = "
-                                           << orbit_yaw_ << ", orbit_theta_ = " << orbit_theta_
-                                           << ", translate_x_ = " << translate_x_
-                                           << ", translate_y_ = " << translate_y_
-                                           << ", zoom_in_ = " << zoom_in_
-                                           << ", zoom_out_ = " << zoom_out_
-                                           << ", move_z_dir_ = " << move_z_dir_ );
+  RCLCPP_INFO_STREAM( node_->get_logger(),
+                      "ViewControlPlugin::update(): orbit_yaw_ = "
+                          << orbit_yaw_ << ", orbit_theta_ = " << orbit_theta_
+                          << ", translate_x_ = " << translate_x_
+                          << ", translate_y_ = " << translate_y_ << ", zoom_in_ = " << zoom_in_
+                          << ", zoom_out_ = " << zoom_out_ << ", move_z_dir_ = " << move_z_dir_ );
   const double dt = 1.0 / 60.0;
 
   /* ------ zoom ----------------------------------------------------- */
@@ -211,4 +210,4 @@ void ViewControlPlugin::deactivate()
 /* ----------------------- plugin export ----------------------------- */
 } // namespace hector_gamepad_manager_plugins
 PLUGINLIB_EXPORT_CLASS( hector_gamepad_manager_plugins::ViewControlPlugin,
-                        hector_gamepad_plugin_interface::GamepadFunctionPlugin)
+                        hector_gamepad_plugin_interface::GamepadFunctionPlugin )

--- a/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/view_control_plugin.cpp
@@ -1,0 +1,214 @@
+//
+// Created by aljoscha-schmidt on 7/13/25.
+//
+#include <hector_gamepad_manager_plugins/view_control_plugin.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+namespace hector_gamepad_manager_plugins
+{
+
+/* --------------------------- initialisation ------------------------ */
+void ViewControlPlugin::initialize( const rclcpp::Node::SharedPtr &node_robot_ns,
+                                    const rclcpp::Node::SharedPtr &node_operator_ns )
+{
+  node_ = node_operator_ns;
+
+  std::string rviz_node_name =
+      node_->declare_parameter<std::string>( getPluginName() + ".rviz_node_name", "" );
+
+  RCLCPP_WARN_STREAM( node_->get_logger(), getPluginName() << ".rviz_node_name: " << rviz_node_name );
+  move_eye_cli_ =
+      node_->create_client<MoveEye>( rviz_node_name + "/hector_view_controller/move_eye" );
+  move_eye_focus_cli_ = node_->create_client<MoveEyeAndFocus>(
+      rviz_node_name + "/hector_view_controller/move_eye_and_focus" );
+  mode_cli_ =
+      node_->create_client<SetViewMode>( rviz_node_name + "/hector_view_controller/set_view_mode" );
+  track_cli_ = node_->create_client<TrackFrame>( rviz_node_name +
+                                                 "/hector_view_controller/set_tracked_frame" );
+
+  /* speed parameters */
+  node_->declare_parameter( getPluginName() + ".orbit_speed", orbit_speed_ );
+  node_->declare_parameter( getPluginName() + ".zoom_speed", zoom_speed_ );
+  node_->declare_parameter( getPluginName() + ".translate_speed", translate_speed_ );
+  node_->get_parameter( getPluginName() + ".orbit_speed", orbit_speed_ );
+  node_->get_parameter( getPluginName() + ".zoom_speed", zoom_speed_ );
+  node_->get_parameter( getPluginName() + ".translate_speed", translate_speed_ );
+}
+
+/* ------------------------------ input ------------------------------ */
+void ViewControlPlugin::handleAxis( const std::string &f, double v )
+{
+  if ( f == "orbit_yaw" )
+    orbit_yaw_ = v;
+  else if ( f == "orbit_theta" )
+    orbit_theta_ = v;
+  else if ( f == "translate_x" )
+    translate_x_ = v;
+  else if ( f == "translate_y" )
+    translate_y_ = v;
+  else if ( f == "zoom_in" )
+    zoom_in_ = v; //  0…+1
+  else if ( f == "zoom_out" )
+    zoom_out_ = v; //  0…+1
+}
+
+void ViewControlPlugin::handlePress( const std::string &f )
+{
+  if ( f == "move_up" )
+    move_z_dir_ = +1;
+  else if ( f == "move_down" )
+    move_z_dir_ = -1;
+  else if ( f == "mode_2d" || f == "mode_3d" ) {
+    auto req = std::make_shared<SetViewMode::Request>();
+    req->mode.mode = ( f == "mode_2d" ) ? hector_rviz_plugins_msgs::msg::ViewMode::MODE_2D
+                                        : hector_rviz_plugins_msgs::msg::ViewMode::MODE_3D;
+    mode_cli_->async_send_request( req );
+  } else if ( f == "track_base" ) {
+    auto req = std::make_shared<TrackFrame::Request>();
+    req->frame = "base_link";
+    track_cli_->async_send_request( req );
+    tracking_on_ = true;
+  } else if ( f == "untrack" ) {
+    auto req = std::make_shared<TrackFrame::Request>();
+    req->frame = "";
+    track_cli_->async_send_request( req );
+    tracking_on_ = false;
+  }
+  /* ------ presets (base_link frame) -------------------------------- */
+  else if ( f.rfind( "preset_", 0 ) == 0 ) {
+    const double d = preset_distance_;
+    Point eye, focus;
+    focus.x = focus.y = focus.z = 0.0; // origin in base_link
+
+    if ( f == "preset_front" ) {
+      eye.x = +d;
+    } else if ( f == "preset_back" ) {
+      eye.x = -d;
+    } else if ( f == "preset_left" ) {
+      eye.y = +d;
+    } else if ( f == "preset_right" ) {
+      eye.y = -d;
+    }
+
+    auto req = std::make_shared<MoveEyeAndFocus::Request>();
+    req->header.frame_id = "base_link";
+    req->eye = eye;
+    req->focus = focus;
+    move_eye_focus_cli_->async_send_request( req );
+
+    orbit_vector_ = Eigen::Vector3d( eye.x, eye.y, eye.z );
+    focus_point_ = focus;
+  }
+}
+
+void ViewControlPlugin::handleRelease( const std::string &f )
+{
+  if ( f == "move_up" || f == "move_down" )
+    move_z_dir_ = 0;
+}
+
+/* ----------------------------- update ------------------------------ */
+void ViewControlPlugin::update()
+{
+  if ( !active_ )
+    return;
+  if ( skip_x_ > counter_ ) {
+    counter_++;
+    return; // skip some frames to avoid flooding the service calls
+  }
+  RCLCPP_INFO_STREAM( node_->get_logger(), "ViewControlPlugin::update(): orbit_yaw_ = "
+                                           << orbit_yaw_ << ", orbit_theta_ = " << orbit_theta_
+                                           << ", translate_x_ = " << translate_x_
+                                           << ", translate_y_ = " << translate_y_
+                                           << ", zoom_in_ = " << zoom_in_
+                                           << ", zoom_out_ = " << zoom_out_
+                                           << ", move_z_dir_ = " << move_z_dir_ );
+  const double dt = 1.0 / 60.0;
+
+  /* ------ zoom ----------------------------------------------------- */
+  /*double zoom_vel = ( zoom_in_ - zoom_out_ ) * zoom_speed_; // in m/s
+  if ( std::fabs( zoom_vel ) > 1e-3 ) {
+    Eigen::Vector3d dz = orbit_vector_.normalized() * zoom_vel * dt;
+    translateWorld( dz );
+  }
+
+  /* ------ translate XY / Z ---------------------------------------- #1#
+  if ( std::fabs( translate_x_ ) > 1e-3 || std::fabs( translate_y_ ) > 1e-3 || move_z_dir_ != 0 ) {
+    Eigen::Vector3d x_axis( 1, 0, 0 ), y_axis( 0, 1, 0 ), z_axis( 0, 0, 1 );
+    Eigen::Vector3d d = ( x_axis * -translate_x_   // left/right
+                          + y_axis * translate_y_  // forward/back in world Y
+                          + z_axis * move_z_dir_ ) // up/down
+                        * translate_speed_ * dt;
+    translateWorld( d );
+  }*/
+
+  /* ------ orbit ---------------------------------------------------- */
+  if ( std::fabs( orbit_yaw_ ) > 1e-3 || std::fabs( orbit_theta_ ) > 1e-3 ) {
+    orbit( orbit_yaw_ * orbit_speed_ * dt, orbit_theta_ * orbit_speed_ * dt );
+  }
+}
+
+/* --------------------------- helpers ------------------------------- */
+bool ViewControlPlugin::waitForServicesOnce()
+{
+  return true;
+  const auto t = std::chrono::seconds( 0 );
+  return move_eye_cli_->wait_for_service( t ) && move_eye_focus_cli_->wait_for_service( t ) &&
+         mode_cli_->wait_for_service( t ) && track_cli_->wait_for_service( t );
+}
+
+void ViewControlPlugin::translateWorld( const Eigen::Vector3d &d )
+{
+  focus_point_.x += d.x();
+  focus_point_.y += d.y();
+  focus_point_.z += d.z();
+  orbit_vector_ += d;
+
+  Point eye;
+  eye.x = focus_point_.x + orbit_vector_.x();
+  eye.y = focus_point_.y + orbit_vector_.y();
+  eye.z = focus_point_.z + orbit_vector_.z();
+
+  auto req = std::make_shared<MoveEye::Request>();
+  req->header.frame_id = "world";
+  req->eye = eye;
+  req->stop_tracking = !tracking_on_;
+  move_eye_cli_->async_send_request( req );
+}
+
+void ViewControlPlugin::orbit( double d_yaw, double d_pitch )
+{
+  Eigen::AngleAxisd yaw( d_yaw, Eigen::Vector3d::UnitZ() );
+  Eigen::Vector3d axis_x = Eigen::Vector3d::UnitZ().cross( eye ).normalized();
+  Eigen::AngleAxisd pitch( d_pitch, axis_x );
+
+  orbit_vector_ = yaw * pitch * orbit_vector_;
+
+  Point eye;
+  eye.x = focus_point_.x + orbit_vector_.x();
+  eye.y = focus_point_.y + orbit_vector_.y();
+  eye.z = focus_point_.z + orbit_vector_.z();
+
+  auto req = std::make_shared<MoveEye::Request>();
+  req->header.frame_id = "world";
+  req->eye = eye;
+  req->stop_tracking = !tracking_on_;
+  move_eye_cli_->async_send_request( req );
+}
+
+void ViewControlPlugin::deactivate()
+{
+  active_ = false;
+
+  /* reset all live inputs so we don't send stale commands when
+     the plugin is re‑activated later */
+  orbit_yaw_ = orbit_theta_ = 0.0;
+  translate_x_ = translate_y_ = 0.0;
+  zoom_in_ = zoom_out_ = 0.0;
+  move_z_dir_ = 0;
+}
+
+/* ----------------------- plugin export ----------------------------- */
+} // namespace hector_gamepad_manager_plugins
+PLUGINLIB_EXPORT_CLASS( hector_gamepad_manager_plugins::ViewControlPlugin,
+                        hector_gamepad_plugin_interface::GamepadFunctionPlugin)

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
@@ -16,7 +16,7 @@ public:
    *
    * @param node The ROS node that the plugin is associated with.
    */
-  virtual void initialize( const rclcpp::Node::SharedPtr &node ) = 0;
+  virtual void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns ) = 0;
 
   /**
    * @brief Returns name of associated plugin

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
@@ -16,7 +16,7 @@ public:
    *
    * @param node The ROS node that the plugin is associated with.
    */
-  virtual void initialize( const rclcpp::Node::SharedPtr &node_robot_ns, const rclcpp::Node::SharedPtr &node_operator_ns ) = 0;
+  virtual void initialize( const rclcpp::Node::SharedPtr &node_robot_ns ) = 0;
 
   /**
    * @brief Returns name of associated plugin


### PR DESCRIPTION
Added View Control Plugin for HectorViewController Interaction. Allows to control the rviz camera perspective with your gamepad.


Features:

  - in driving mode camera control: Rotate the camera perspective using gamepad input.
-  Dedicated view_control configuration:
        - Rotate, translate, and zoom the current view using the gamepad axes
      - Tracking control: Press 'B' to toggle tracking of a target frame (configurable via parameter).
      - 2D mode toggle:  Press 'Y' to switch between 3D and 2D view modes.
      
Depends on https://github.com/tu-darmstadt-ros-pkg/hector_rviz_plugins/compare/feature/gamepad_view_controller?expand=1