### PR TITLE
Refactored configs per function mapping

### DIFF
--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -66,7 +66,9 @@ buttons:
 
   8: # Button Guide (Manufacturer Button)
     plugin: "hector_gamepad_manager_plugins::BlackboardPlugin"
-    function: "toggle/invert_steering"
+    function: "toggle"
+    args:
+      name: "invert_steering"
 
   9: # Left joystick press
     plugin: ""
@@ -119,16 +121,28 @@ buttons:
 
   21: # Cross left
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "flipper_group/tub"
+    function: "go_to_pose"
+    args:
+      group: "flipper_group"
+      pose: "tub"
 
   22: # Cross right
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "flipper_group/compact"
+    function: "go_to_pose"
+    args:
+      group: "flipper_group"
+      pose: "compact"
 
   23: # Cross up
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "flipper_group/up"
+    function: "go_to_pose"
+    args:
+      group: "flipper_group"
+      pose: "up"
 
   24: # Cross down
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "flipper_group/flat"
+    function: "go_to_pose"
+    args:
+      group: "flipper_group"
+      pose: "flat"

--- a/hector_gamepad_manager/config/manipulation.yaml
+++ b/hector_gamepad_manager/config/manipulation.yaml
@@ -66,7 +66,9 @@ buttons:
 
   8: # Button Guide (Manufacturer Button)
     plugin: "hector_gamepad_manager_plugins::BlackboardPlugin"
-    function: "toggle/invert_steering"
+    function: "toggle"
+    args:
+      name: "invert_steering"
 
   9: # Left joystick press
     plugin: ""
@@ -119,11 +121,19 @@ buttons:
 
   21: # Cross left
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "arm_group/back|front"
+    function: "go_to_pose"
+    args:
+      group: "arm_group"
+      pose: "back"
+      inverted_pose: "front"
 
   22: # Cross right
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "arm_group/front|back"
+    function: "go_to_pose"
+    args:
+      group: "arm_group"
+      pose: "front"
+      inverted_pose: "back"
 
   23: # Cross up
     plugin: ""
@@ -131,4 +141,7 @@ buttons:
 
   24: # Cross down
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
-    function: "arm_group/folded"
+    function: "go_to_pose"
+    args:
+      group: "arm_group"
+      pose: "folded"

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -119,6 +119,7 @@ private:
    * @return True if the mappings were initialized successfully, false otherwise.
    */
   bool initMappings( const YAML::Node &config, const std::string &type,
+                     const std::string &config_name,
                      std::unordered_map<int, FunctionMapping> &mappings );
 
   /**

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/blackboard_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/blackboard_plugin.hpp
@@ -25,14 +25,15 @@ class BlackboardPlugin : public hector_gamepad_plugin_interface::GamepadFunction
 {
 public:
   void initialize( const rclcpp::Node::SharedPtr &node ) override;
-  std::string getPluginName() override;
 
   // Button interface
-  void handlePress( const std::string &function ) override;
-  void handleRelease( const std::string &function ) override;
+  void handlePress( const std::string &function, const std::string &id ) override;
+  void handleRelease( const std::string &function, const std::string &id ) override;
 
   // Axis interface (unused here)
-  void handleAxis( const std::string &function, const double value ) override { }
+  void handleAxis( const std::string &function, const std::string &id, const double value ) override
+  {
+  }
 
   // Lifecycle-ish
   void activate() override;
@@ -42,10 +43,6 @@ public:
 private:
   rclcpp::Node::SharedPtr node_;
   bool active_{ false };
-
-  // Helpers
-  static bool startsWith( const std::string &s, const char *prefix );
-  static std::vector<std::string> split( const std::string &s, char delim );
 
   void onToggle( const std::string &var ) const;
   void onHoldPress( const std::string &var ) const;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/drive_plugin.hpp
@@ -13,13 +13,11 @@ class DrivePlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugi
 public:
   void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
-  std::string getPluginName() override;
+  void handleAxis( const std::string &function, const std::string &id, const double value ) override;
 
-  void handleAxis( const std::string &function, double value ) override;
+  void handlePress( const std::string &function, const std::string &id ) override;
 
-  void handlePress( const std::string &function ) override;
-
-  void handleRelease( const std::string &function ) override;
+  void handleRelease( const std::string &function, const std::string &id ) override;
 
   void update() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -14,13 +14,11 @@ class FlipperPlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlu
 public:
   void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
-  std::string getPluginName() override;
+  void handlePress( const std::string &function, const std::string &id ) override;
 
-  void handlePress( const std::string &function ) override;
+  void handleRelease( const std::string &function, const std::string &id ) override;
 
-  void handleRelease( const std::string &function ) override;
-
-  void handleAxis( const std::string &function, const double value ) override;
+  void handleAxis( const std::string &function, const std::string &id, const double value ) override;
 
   void update() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
@@ -18,12 +18,10 @@ class ManipulationPlugin final : public hector_gamepad_plugin_interface::Gamepad
 public:
   void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
-  std::string getPluginName() override;
+  void handlePress( const std::string &function, const std::string &id ) override;
+  void handleRelease( const std::string &function, const std::string &id ) override;
 
-  void handlePress( const std::string &function ) override;
-  void handleRelease( const std::string &function ) override;
-
-  void handleAxis( const std::string &function, const double value ) override;
+  void handleAxis( const std::string &function, const std::string &id, const double value ) override;
 
   void update() override;
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/moveit_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/moveit_plugin.hpp
@@ -20,10 +20,8 @@ class MoveitPlugin final : public hector_gamepad_plugin_interface::GamepadFuncti
 public:
   void initialize( const rclcpp::Node::SharedPtr &node ) override;
 
-  std::string getPluginName() override;
-
-  void handlePress( const std::string &function ) override;
-  void handleRelease( const std::string &function ) override;
+  void handlePress( const std::string &function, const std::string &id ) override;
+  void handleRelease( const std::string &function, const std::string &id ) override;
 
   void update() override;
 
@@ -46,8 +44,8 @@ private:
   double getNormalizedJointPosition( const std::string &name ) const;
 
   static std::string toGroupPoseName( const std::string &group_name, const std::string &pose_name );
-  std::pair<std::string, std::string> fromGroupPoseName( const std::string &group_pose_name ) const;
-
+  std::pair<std::string, std::string> functionIdToGroupGroupAndPose( const std::string &function,
+                                                                     const std::string &id ) const;
   bool active_ = false;
   bool request_active_ = false;
   double joint_tolerance_ = 0.05;

--- a/hector_gamepad_manager_plugins/src/drive_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/drive_plugin.cpp
@@ -36,9 +36,7 @@ void DrivePlugin::initialize( const rclcpp::Node::SharedPtr &node )
       node_->create_publisher<geometry_msgs::msg::TwistStamped>( "cmd_vel", 1 );
 }
 
-std::string DrivePlugin::getPluginName() { return "drive_plugin"; }
-
-void DrivePlugin::handleAxis( const std::string &function, const double value )
+void DrivePlugin::handleAxis( const std::string &function, const std::string &id, const double value )
 {
   if ( function == "drive" ) {
     drive_value_ = value;
@@ -47,7 +45,7 @@ void DrivePlugin::handleAxis( const std::string &function, const double value )
   }
 }
 
-void DrivePlugin::handlePress( const std::string &function )
+void DrivePlugin::handlePress( const std::string &function, const std::string &id )
 {
   if ( function == "fast" ) {
     fast_mode_active_ = true;
@@ -56,7 +54,7 @@ void DrivePlugin::handlePress( const std::string &function )
   }
 }
 
-void DrivePlugin::handleRelease( const std::string &function )
+void DrivePlugin::handleRelease( const std::string &function, const std::string &id )
 {
   if ( function == "fast" ) {
     fast_mode_active_ = false;

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -49,9 +49,7 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   active_ = true;
 }
 
-std::string FlipperPlugin::getPluginName() { return "flipper_plugin"; }
-
-void FlipperPlugin::handlePress( const std::string &function )
+void FlipperPlugin::handlePress( const std::string &function, const std::string &id )
 {
   // Activate respective individual mode only if other is inactive
   if ( function == "individual_front_flipper_control_mode" ) {
@@ -70,7 +68,7 @@ void FlipperPlugin::handlePress( const std::string &function )
     handleBasicControlInput( 1, true, function );
 }
 
-void FlipperPlugin::handleRelease( const std::string &function )
+void FlipperPlugin::handleRelease( const std::string &function, const std::string &id )
 {
   // Activate respective individual mode only if other is inactive
   if ( function == "individual_front_flipper_control_mode" ) {
@@ -95,7 +93,8 @@ void FlipperPlugin::handleRelease( const std::string &function )
     handleBasicControlInput( 0, true, function );
 }
 
-void FlipperPlugin::handleAxis( const std::string &function, const double value )
+void FlipperPlugin::handleAxis( const std::string &function, const std::string &id,
+                                const double value )
 {
   if ( individual_front_flipper_mode_ || individual_back_flipper_mode_ )
     handleIndividualFlipperControlInput( -1 * value, false, function );

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -56,9 +56,7 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   controller_helper_.initialize( node, plugin_namespace );
 }
 
-std::string ManipulationPlugin::getPluginName() { return "manipulation_plugin"; }
-
-void ManipulationPlugin::handlePress( const std::string &function )
+void ManipulationPlugin::handlePress( const std::string &function, const std::string &id )
 {
   if ( function == "hold_mode" ) {
     hold_mode_change_requested_ = true;
@@ -74,7 +72,7 @@ void ManipulationPlugin::handlePress( const std::string &function )
   }
 }
 
-void ManipulationPlugin::handleRelease( const std::string &function )
+void ManipulationPlugin::handleRelease( const std::string &function, const std::string &id )
 {
   if ( function == "hold_mode" ) {
     hold_mode_change_requested_ = true;
@@ -90,7 +88,8 @@ void ManipulationPlugin::handleRelease( const std::string &function )
   }
 }
 
-void ManipulationPlugin::handleAxis( const std::string &function, const double value )
+void ManipulationPlugin::handleAxis( const std::string &function, const std::string &id,
+                                     const double value )
 {
   if ( function == "move_left_right" ) {
     move_left_right_ = value;

--- a/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
@@ -55,9 +55,7 @@ void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node )
       [this]( const sensor_msgs::msg::JointState::SharedPtr msg ) { joint_state_ = *msg; } );
 }
 
-std::string MoveitPlugin::getPluginName() { return "moveit_plugin"; }
-
-void MoveitPlugin::handlePress( const std::string &function )
+void MoveitPlugin::handlePress( const std::string &function, const std::string &id )
 {
   if ( !active_ )
     return;
@@ -69,26 +67,28 @@ void MoveitPlugin::handlePress( const std::string &function )
     RCLCPP_WARN( node_->get_logger(), "Moveit action still active. Ignoring new request." );
     return;
   }
-  auto [group_name, pose_name] = fromGroupPoseName( function );
-  const std::string function_repl = toGroupPoseName( group_name, pose_name );
-  if ( named_poses_.count( function_repl ) > 0 ) {
-    controller_helper_.switchControllers( start_controllers_ );
-    const auto [group, pose] = fromGroupPoseName( function_repl );
-    RCLCPP_WARN( node_->get_logger(), "Start Moveit Planning & Execution [%s]",
-                 function_repl.c_str() );
-    request_active_ = true;
-    sendNamedPoseGoal( group, pose );
-  } else {
-    RCLCPP_WARN( node_->get_logger(), "No pose named %s found", function_repl.c_str() );
+  if ( function == "go_to_pose" ) {
+    auto [group, pose] = functionIdToGroupGroupAndPose( function, id );
+    if ( named_poses_.count( toGroupPoseName( group, pose ) ) > 0 ) {
+      controller_helper_.switchControllers( start_controllers_ );
+      RCLCPP_WARN( node_->get_logger(),
+                   "Start Moveit Planning & Execution of pose [%s] in group [%s]", pose.c_str(),
+                   group.c_str() );
+      request_active_ = true;
+      sendNamedPoseGoal( group, pose );
+    } else {
+      RCLCPP_WARN( node_->get_logger(), "No pose named %s found in group %s", pose.c_str(),
+                   group.c_str() );
+    }
   }
 }
 
-void MoveitPlugin::handleRelease( const std::string &function )
+void MoveitPlugin::handleRelease( const std::string &function, const std::string &id )
 {
   if ( !active_ )
     return;
-  // function is <group_name>_<pose_name>
-  if ( named_poses_.count( function ) > 0 ) {
+  auto [group, pose] = functionIdToGroupGroupAndPose( function, id );
+  if ( named_poses_.count( toGroupPoseName( group, pose ) ) > 0 ) {
     cancelGoal(); // cancels all current goals
   }
 }
@@ -245,25 +245,14 @@ std::string MoveitPlugin::toGroupPoseName( const std::string &group_name,
 }
 
 std::pair<std::string, std::string>
-MoveitPlugin::fromGroupPoseName( const std::string &group_pose_name ) const
+MoveitPlugin::functionIdToGroupGroupAndPose( const std::string &function, const std::string &id ) const
 {
-  // function is <group_name>/<pose_name>|<pose_name_inverted> (e.g. "arm/front|back")
-  // inverted pose is optional
-  const auto pos = group_pose_name.find_last_of( '/' );
-  if ( pos == std::string::npos ) {
-    return { "", "" };
-  }
-  std::string group_name = group_pose_name.substr( 0, pos );
-  std::string pose_name = group_pose_name.substr( pos + 1 );
-  // check if inverted pose exists
-  if ( group_pose_name.substr( pos + 1 ).find( '|' ) != std::string::npos ) {
-    // inverted pose exists
-    const bool inverted = blackboard_->value_or<bool>( "invert_steering", false );
-    const auto inv_pose = group_pose_name.find_last_of( '|' );
-    pose_name = inverted ? group_pose_name.substr( inv_pose + 1 )
-                         : group_pose_name.substr( pos + 1, inv_pose - pos - 1 );
-  }
-  return { group_name, pose_name };
+  const auto &group = getConfigValueOr<std::string>( id, "group", "" );
+  const auto &normal_pose = getConfigValueOr<std::string>( id, "pose", "" );
+  const auto &inverted_pose = getConfigValueOr<std::string>( id, "inverted_pose", "" );
+  const auto &inverted_steering = blackboard_->value_or<bool>( "inverted_steering", false );
+  const auto &pose = inverted_steering ? inverted_pose : normal_pose;
+  return { group, pose };
 }
 
 } // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_plugin_interface/CMakeLists.txt
+++ b/hector_gamepad_plugin_interface/CMakeLists.txt
@@ -11,7 +11,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-
+find_package(rclcpp REQUIRED)
+find_package(yaml-cpp REQUIRED)
 # Header-only interface target
 add_library(${PROJECT_NAME} INTERFACE)
 
@@ -19,6 +20,7 @@ target_include_directories(
   ${PROJECT_NAME}
   INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include>")
+target_link_libraries(${PROJECT_NAME} INTERFACE yaml-cpp)
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -42,6 +44,14 @@ if(BUILD_TESTING)
     target_compile_features(test_blackboard PRIVATE cxx_std_17)
     target_compile_options(test_blackboard PRIVATE -Wall -Wextra -Wpedantic)
   endif()
+  ament_add_gtest(test_blackboard_yaml test/test_blackboard_yaml.cpp)
+  if(TARGET test_blackboard_yaml)
+    target_link_libraries(test_blackboard_yaml ${PROJECT_NAME})
+    target_compile_features(test_blackboard_yaml PRIVATE cxx_std_17)
+    target_compile_options(test_blackboard_yaml PRIVATE -Wall -Wextra
+                                                        -Wpedantic)
+  endif()
 endif()
 
+ament_export_dependencies(yaml-cpp)
 ament_package()

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
@@ -2,6 +2,8 @@
 #define HECTOR_GAMEPAD_MANAGER_GAMEPAD_FUNCTION_PLUGIN_HPP
 
 #include "blackboard.hpp"
+#include <algorithm>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
 
 namespace hector_gamepad_plugin_interface
@@ -12,17 +14,14 @@ public:
   // Destructor
   virtual ~GamepadFunctionPlugin() = default;
 
-  void initializePlugin( const rclcpp::Node::SharedPtr &node, std::shared_ptr<Blackboard> blackborad )
+  void initializePlugin( const rclcpp::Node::SharedPtr &node, const std::string &plugin_id,
+                         std::shared_ptr<Blackboard> blackborad )
   {
+    node_ = node;
     blackboard_ = blackborad;
+    setPluginId( plugin_id );
     initialize( node );
   }
-
-  /**
-   * @brief Returns name of associated plugin
-   *
-   */
-  virtual std::string getPluginName() = 0;
 
   /**
    * @brief Handle button input events.
@@ -30,25 +29,26 @@ public:
    * @param function The function name that is associated with the button.
    * @param pressed True if the button is pressed, false otherwise.
    */
-  virtual void handleButton( const std::string &function, const bool pressed )
+  virtual void handleButton( const std::string &function, const std::string &id, const bool pressed )
   {
-    if ( button_states_.count( function ) == 0 ) {
-      button_states_[function] = false;
+    const std::string unique_function = function + "_" + id;
+    if ( button_states_.count( unique_function ) == 0 ) {
+      button_states_[unique_function] = false;
     }
 
     if ( pressed ) {
-      if ( button_states_[function] ) {
-        handleHold( function );
+      if ( button_states_[unique_function] ) {
+        handleHold( function, id );
       } else {
-        handlePress( function );
+        handlePress( function, id );
       }
     } else {
-      if ( button_states_[function] ) {
-        handleRelease( function );
+      if ( button_states_[unique_function] ) {
+        handleRelease( function, id );
       }
     }
 
-    button_states_[function] = pressed;
+    button_states_[unique_function] = pressed;
   }
 
   /**
@@ -57,9 +57,10 @@ public:
    * @param function The function name that is associated with the axis.
    * @param value The value of the axis input event.
    */
-  virtual void handleAxis( const std::string &function, double value )
+  virtual void handleAxis( const std::string &function, const std::string &id, double value )
   {
     (void)function;
+    (void)id;
     (void)value;
   }
 
@@ -68,21 +69,41 @@ public:
    *
    * @param function The name of the function that is associated with the input event.
    */
-  virtual void handlePress( const std::string &function ) { (void)function; }
+  virtual void handlePress( const std::string &function, const std::string &id )
+  {
+    (void)function;
+    (void)id;
+  }
 
   /**
    * @brief Function for handling input events where the button or axis is held down.
    *
    * @param function The name of the function that is associated with the input event.
    */
-  virtual void handleHold( const std::string &function ) { (void)function; }
+  virtual void handleHold( const std::string &function, const std::string &id )
+  {
+    (void)function;
+    (void)id;
+  }
 
   /**
    * @brief Function for handling input events where the button or axis is released.
    *
    * @param function The name of the function that is associated with the input event.
    */
-  virtual void handleRelease( const std::string &function ) { (void)function; }
+  virtual void handleRelease( const std::string &function, const std::string &id )
+  {
+    (void)function;
+    (void)id;
+  }
+
+  template<typename T>
+  T getConfigValueOr( const std::string &id, const std::string &param,
+                      const T &default_value = T() ) const
+  {
+    std::string key = plugin_id_ + "_" + id + "/" + param;
+    return blackboard_->value_or<T>( key, default_value );
+  }
 
   /**
    * @brief Update function that is called periodically to update the plugin state after handling input events.
@@ -105,6 +126,24 @@ public:
    */
   bool isActive() const { return active_; }
 
+  /**
+   * @brief Get the plugin ID.
+   * @return The plugin ID.
+   */
+  std::string getPluginId() const { return plugin_id_; }
+
+  /**
+   * @brief Get the plugin name.
+   * @return The plugin name.
+   */
+  std::string getPluginName() const { return plugin_name_; }
+
+  /**
+   * @brief Get the plugin namespace.
+   * @return The plugin namespace.
+   */
+  std::string getPluginNamespace() const { return plugin_namespace_; }
+
 protected:
   /**
    * @brief Initialize function that is called when the plugin is loaded.
@@ -112,6 +151,39 @@ protected:
    * @param node The ROS node that the plugin is associated with.
    */
   virtual void initialize( const rclcpp::Node::SharedPtr &node ) = 0;
+  void setPluginId( const std::string &plugin_id )
+  {
+    plugin_id_ = plugin_id;
+    // extract name and namespace from plugin_id
+    // e.g. "hector_gamepad_manager_plugins::moveit_plugin" -> name: "moveit_plugin", namespace: "hector_gamepad_manager_plugins"
+    size_t pos = plugin_id_.find( "::" );
+    if ( pos != std::string::npos ) {
+      plugin_name_ = plugin_id_.substr( pos + 2 );
+      plugin_namespace_ = plugin_id_.substr( 0, pos );
+    } else {
+      plugin_name_ = plugin_id_;
+      plugin_namespace_ = "";
+    }
+    // make sure the plugin name is snake_case
+    plugin_name_ = camel_to_snake( plugin_name_ );
+  }
+  std::string camel_to_snake( const std::string &input )
+  {
+    std::string result;
+    result.reserve( input.size() * 2 ); // conservative allocation
+    for ( size_t i = 0; i < input.size(); ++i ) {
+      char c = input[i];
+      if ( std::isupper( static_cast<unsigned char>( c ) ) ) {
+        if ( i > 0 ) {
+          result.push_back( '_' );
+        }
+        result.push_back( static_cast<char>( std::tolower( static_cast<unsigned char>( c ) ) ) );
+      } else {
+        result.push_back( c );
+      }
+    }
+    return result;
+  }
   // The ROS node
   rclcpp::Node::SharedPtr node_;
 
@@ -120,7 +192,9 @@ protected:
 
   // The current state of the buttons per function.
   std::unordered_map<std::string, bool> button_states_;
-
+  std::string plugin_id_;
+  std::string plugin_name_;
+  std::string plugin_namespace_;
   std::shared_ptr<Blackboard> blackboard_;
 };
 } // namespace hector_gamepad_plugin_interface

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
@@ -15,10 +15,10 @@ public:
   virtual ~GamepadFunctionPlugin() = default;
 
   void initializePlugin( const rclcpp::Node::SharedPtr &node, const std::string &plugin_id,
-                         std::shared_ptr<Blackboard> blackborad )
+                         std::shared_ptr<Blackboard> blackboard )
   {
     node_ = node;
-    blackboard_ = blackborad;
+    blackboard_ = blackboard;
     setPluginId( plugin_id );
     initialize( node );
   }

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/yaml_helper.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/yaml_helper.hpp
@@ -1,0 +1,45 @@
+#include <optional>
+#include <yaml-cpp/yaml.h>
+
+#ifndef HECTOR_GAMEPAD_PLUGIN_INTERFACE_YAML_HELPER_HPP
+  #define HECTOR_GAMEPAD_PLUGIN_INTERFACE_YAML_HELPER_HPP
+namespace hector_gamepad_plugin_interface
+{
+
+inline std::optional<bool> is_bool( const YAML::Node &node )
+{
+  bool bool_value{};
+  if ( YAML::convert<bool>::decode( node, bool_value ) ) {
+    return bool_value;
+  }
+  return std::nullopt;
+}
+inline std::optional<int64_t> is_int( const YAML::Node &node )
+{
+  int64_t int_value{};
+  if ( YAML::convert<int64_t>::decode( node, int_value ) ) {
+    return int_value;
+  }
+  return std::nullopt;
+}
+// Note: will return true for both integer and floating-point values!
+// Make sure to first check for integer if you want to distinguish them.
+inline std::optional<double> is_double( const YAML::Node &node )
+{
+  double double_value{};
+  if ( YAML::convert<double>::decode( node, double_value ) ) {
+    return double_value;
+  }
+  return std::nullopt;
+}
+// Note: will return a strung for int, double, and string values.
+inline std::optional<std::string> is_string( const YAML::Node &node )
+{
+  std::string string_value{};
+  if ( YAML::convert<std::string>::decode( node, string_value ) ) {
+    return string_value;
+  }
+  return std::nullopt;
+}
+} // namespace hector_gamepad_plugin_interface
+#endif // HECTOR_GAMEPAD_PLUGIN_INTERFACE_YAML_HELPER_HPP

--- a/hector_gamepad_plugin_interface/package.xml
+++ b/hector_gamepad_plugin_interface/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/hector_gamepad_plugin_interface/test/test_blackboard_yaml.cpp
+++ b/hector_gamepad_plugin_interface/test/test_blackboard_yaml.cpp
@@ -1,0 +1,299 @@
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+#include <hector_gamepad_plugin_interface/blackboard.hpp>
+
+// If your yaml_helper.hpp isn’t visible to tests, add minimal fallbacks here:
+// But the Blackboard uses the project’s is_* helpers, so we won’t redefine them.
+
+using hector_gamepad_plugin_interface::Blackboard;
+
+namespace
+{
+
+// Small helpers to probe existence & type
+template<typename T>
+bool has_as( const Blackboard &bb, const std::string &key, T *out = nullptr )
+{
+  if ( auto p = bb.try_get<T>( key ) ) {
+    if ( out )
+      *out = *p;
+    return true;
+  }
+  return false;
+}
+
+} // namespace
+
+TEST( BlackboardYaml, ScalarMapBasic )
+{
+  const char *txt = R"(
+args:
+  b_true: true
+  b_yes:  yes
+  i:      42
+  d:      3.14
+  s:      "hello"
+)";
+  YAML::Node root = YAML::Load( txt );
+  ASSERT_TRUE( root["args"] );
+
+  Blackboard bb;
+  EXPECT_TRUE( bb.set_from_yaml( root["args"], "prefix" ) );
+
+  bool b{};
+  int64_t i{};
+  double d{};
+  std::string s;
+
+  EXPECT_TRUE( has_as<bool>( bb, "prefix/b_true", &b ) ) << "b_true missing/typed wrong";
+  EXPECT_TRUE( b );
+
+  EXPECT_TRUE( has_as<bool>( bb, "prefix/b_yes", &b ) );
+  EXPECT_TRUE( b );
+
+  EXPECT_TRUE( has_as<int64_t>( bb, "prefix/i", &i ) );
+  EXPECT_EQ( i, 42 );
+
+  EXPECT_TRUE( has_as<double>( bb, "prefix/d", &d ) );
+  EXPECT_DOUBLE_EQ( d, 3.14 );
+
+  EXPECT_TRUE( has_as<std::string>( bb, "prefix/s", &s ) );
+  EXPECT_EQ( s, "hello" );
+}
+
+TEST( BlackboardYaml, SequenceHomogeneous )
+{
+  const char *txt = R"(
+args:
+  ints:    [1, 2, 3]
+  bools:   [true, false, true]
+  doubles: [1.0, 2.5, 3]   # 3 is acceptable as double
+  strings: ["a", "b", "c"]
+)";
+  YAML::Node root = YAML::Load( txt );
+  Blackboard bb;
+  ASSERT_TRUE( root["args"] );
+  EXPECT_TRUE( bb.set_from_yaml( root["args"], "p" ) );
+
+  std::vector<int64_t> vi;
+  std::vector<bool> vb = { false, true, false };
+  std::vector<double> vd = { 0.0, 0.0, 0.0 };
+  std::vector<std::string> vs = { "", "", "" };
+
+  ASSERT_TRUE( has_as<std::vector<int64_t>>( bb, "p/ints", &vi ) );
+  EXPECT_EQ( ( std::vector<int64_t>{ 1, 2, 3 } ), vi );
+
+  ASSERT_TRUE( has_as<std::vector<bool>>( bb, "p/bools", &vb ) );
+  ASSERT_EQ( 3u, vb.size() );
+  EXPECT_TRUE( vb[0] );
+  EXPECT_FALSE( vb[1] );
+  EXPECT_TRUE( vb[2] );
+
+  ASSERT_TRUE( has_as<std::vector<double>>( bb, "p/doubles", &vd ) );
+  ASSERT_EQ( 3u, vd.size() );
+  EXPECT_DOUBLE_EQ( vd[0], 1.0 );
+  EXPECT_DOUBLE_EQ( vd[1], 2.5 );
+  EXPECT_DOUBLE_EQ( vd[2], 3.0 );
+
+  ASSERT_TRUE( has_as<std::vector<std::string>>( bb, "p/strings", &vs ) );
+  EXPECT_EQ( ( std::vector<std::string>{ "a", "b", "c" } ), vs );
+}
+
+TEST( BlackboardYaml, SequenceMixedTransformedToStringVec )
+{
+  const char *txt = R"(
+args:
+  mixed: [1, "a"]
+)";
+  YAML::Node root = YAML::Load( txt );
+  Blackboard bb;
+  ASSERT_TRUE( root["args"] );
+  // set_from_yaml should return false because mixed scalar types are not allowed
+  EXPECT_TRUE( bb.set_from_yaml( root["args"], "p" ) );
+  // Ensure no key was created
+  ASSERT_TRUE( bb.contains( "p/mixed" ) );
+  auto &v = bb.at<std::vector<std::string>>( "p/mixed" );
+  EXPECT_EQ( v[0], "1" ); // int 1 transformed to string
+  EXPECT_EQ( v[1], "a" ); // string "a" remains unchanged
+}
+
+TEST( BlackboardYaml, SequenceWithMapReject )
+{
+  const char *txt = R"(
+args:
+  bad: [ {a:1}, 2 ]
+)";
+  YAML::Node root = YAML::Load( txt );
+  Blackboard bb;
+  ASSERT_TRUE( root["args"] );
+  EXPECT_FALSE( bb.set_from_yaml( root["args"], "p" ) );
+  EXPECT_FALSE( bb.contains( "p/bad" ) );
+}
+
+TEST( BlackboardYaml, NestedMapRecursion )
+{
+  const char *txt = R"(
+args:
+  nested:
+    level1:
+      level2:
+        a: 1
+        b: "x"
+      c: 1.4
+)";
+  YAML::Node root = YAML::Load( txt );
+  Blackboard bb;
+  ASSERT_TRUE( root["args"] );
+  EXPECT_TRUE( bb.set_from_yaml( root["args"], "root" ) );
+
+  int64_t a{};
+  std::string b;
+  double c{};
+  EXPECT_TRUE( has_as<int64_t>( bb, "root/nested/level1/level2/a", &a ) );
+  EXPECT_EQ( a, 1 );
+  EXPECT_TRUE( has_as<std::string>( bb, "root/nested/level1/level2/b", &b ) );
+  EXPECT_EQ( b, "x" );
+  EXPECT_TRUE( has_as<double>( bb, "root/nested/level1/c", &c ) );
+  EXPECT_DOUBLE_EQ( c, 1.4 );
+}
+
+TEST( BlackboardYaml, TopLevelSequenceAtPrefix )
+{
+  YAML::Node seq = YAML::Load( "[10, 20, 30]" );
+  Blackboard bb;
+  EXPECT_TRUE( bb.set_from_yaml( seq, "top" ) );
+
+  std::vector<int64_t> v;
+  ASSERT_TRUE( has_as<std::vector<int64_t>>( bb, "top", &v ) );
+  EXPECT_EQ( ( std::vector<int64_t>{ 10, 20, 30 } ), v );
+}
+
+TEST( BlackboardYaml, EmptySequencePolicy )
+{
+  YAML::Node seq = YAML::Load( "[]" );
+  Blackboard bb;
+  EXPECT_TRUE( bb.set_from_yaml( seq, "empty" ) );
+
+  // By policy we store empty vector<string>
+  std::vector<std::string> v;
+  ASSERT_TRUE( has_as<std::vector<std::string>>( bb, "empty", &v ) );
+  EXPECT_TRUE( v.empty() );
+}
+
+TEST( BlackboardYaml, NullValuesAreIgnored )
+{
+  YAML::Node root = YAML::Load( R"(
+args:
+  some: null
+  other: 1
+)" );
+  Blackboard bb;
+  ASSERT_TRUE( root["args"] );
+  EXPECT_TRUE( bb.set_from_yaml( root["args"], "p" ) );
+  EXPECT_FALSE( bb.contains( "p/some" ) );
+  int64_t other{};
+  EXPECT_TRUE( has_as<int64_t>( bb, "p/other", &other ) );
+  EXPECT_EQ( other, 1 );
+}
+
+TEST( BlackboardYaml, OverwriteExistingKey )
+{
+  Blackboard bb;
+  // First set
+  YAML::Node n1 = YAML::Load( "a: 1" );
+  EXPECT_TRUE( bb.set_from_yaml( n1, "k" ) );
+  int64_t a{};
+  ASSERT_TRUE( has_as<int64_t>( bb, "k/a", &a ) );
+  EXPECT_EQ( a, 1 );
+
+  // Overwrite with double
+  YAML::Node n2 = YAML::Load( "a: 2.5" );
+  EXPECT_TRUE( bb.set_from_yaml( n2, "k" ) );
+  double d{};
+  ASSERT_TRUE( has_as<double>( bb, "k/a", &d ) );
+  EXPECT_DOUBLE_EQ( d, 2.5 );
+}
+
+TEST( BlackboardYaml, NumericEdgeCases )
+{
+  YAML::Node n = YAML::Load( R"(
+a: 1e2
+b: 0x10
+c: 07
+d: "1.0"   # double
+)" );
+  Blackboard bb;
+  EXPECT_TRUE( bb.set_from_yaml( n, "n" ) );
+
+  double a{};
+  ASSERT_TRUE( has_as<double>( bb, "n/a", &a ) );
+  EXPECT_DOUBLE_EQ( a, 100.0 );
+
+  // Depending on yaml-cpp, hex and octal decode as int
+  int64_t b{};
+  ASSERT_TRUE( has_as<int64_t>( bb, "n/b", &b ) );
+  EXPECT_EQ( b, 16 );
+
+  int64_t c{};
+  ASSERT_TRUE( has_as<int64_t>( bb, "n/c", &c ) );
+  EXPECT_EQ( c, 7 );
+
+  double d;
+  ASSERT_TRUE( has_as<double>( bb, "n/d", &d ) );
+  EXPECT_NEAR( d, 1.0, 1e-6 ); // check double conversion
+}
+
+TEST( BlackboardYaml, BoolSynonyms )
+{
+  YAML::Node n = YAML::Load( R"(
+t1: yes
+t2: On
+f1: no
+f2: OFF
+f3: false
+f4: TRUE
+f5: False
+f6: true
+)" );
+  Blackboard bb;
+  EXPECT_TRUE( bb.set_from_yaml( n, "b" ) );
+
+  bool t1{}, t2{}, f1{}, f2{}, f3{}, f4{}, f5{}, f6{};
+  ASSERT_TRUE( has_as<bool>( bb, "b/t1", &t1 ) );
+  EXPECT_TRUE( t1 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/t2", &t2 ) );
+  EXPECT_TRUE( t2 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/f1", &f1 ) );
+  EXPECT_FALSE( f1 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/f2", &f2 ) );
+  EXPECT_FALSE( f2 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/f3", &f3 ) );
+  EXPECT_FALSE( f3 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/f4", &f4 ) );
+  EXPECT_TRUE( f4 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/f5", &f5 ) );
+  EXPECT_FALSE( f5 );
+  ASSERT_TRUE( has_as<bool>( bb, "b/f6", &f6 ) );
+  EXPECT_TRUE( f6 );
+}
+
+TEST( BlackboardYaml, EmptyStringScalar )
+{
+  YAML::Node n = YAML::Load( "s: ''" );
+  Blackboard bb;
+  EXPECT_TRUE( bb.set_from_yaml( n, "x" ) );
+  std::string s;
+  ASSERT_TRUE( has_as<std::string>( bb, "x/s", &s ) );
+  EXPECT_TRUE( s.empty() );
+}
+
+int main( int argc, char **argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Refactor: Parameters per Function Mapping

Previously, plugins had no clean way to receive per-function parameters. For example, the MoveIt plugin embedded arguments directly into the function name, forcing string parsing on every call.

This PR introduces a structured **parameters-per-function mapping**, for example:

```yaml
24: # Cross down
  plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
  function: "go_to_pose"
  args:
    group: "arm_group"
    pose: "folded"
```

* Parameters are parsed from YAML and stored in the **blackboard** under a unique identifier (ensuring no collisions across or within configs).
* Plugins retrieve values via:

  ```cpp
  T getConfigValueOr(const std::string &id,
                     const std::string &param,
                     const T &default_value = T()) const;
  ```
* Added tests for parsing and storing YAML arguments in the blackboard.
* Updated **Blackboard plugin** and **MoveIt plugin** to use the new parameter mapping style.
