### PR TITLE
Feature/feedback manager

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -68,6 +68,10 @@ jobs:
           path: src/hector_ros_controllers
       - uses: actions/checkout@v4
         with:
+          repository: tu-darmstadt-ros-pkg/ad_kinematics
+          path: src/ad_kinematics
+      - uses: actions/checkout@v4
+        with:
           path: src/repo
       - name: rosdep
         run: |
@@ -78,8 +82,9 @@ jobs:
           source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
           colcon build
        # TODO: Enable tests After Fixing them: they sometimes fail in the CI even though they pass locally
-#      - name: test
+       # Only run tests for the packages in this repo
+#      - name: test --packages-select he
 #        run: |
 #          source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-#          colcon test
+#          colcon test --packages-select-regex hector_gamepad-*
 #          colcon test-result --verbose

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -56,8 +56,8 @@ jobs:
           path: src/hector_ros2_utils
       - uses: actions/checkout@v4
         with:
-          repository: tu-darmstadt-ros-pkg/hector_transmission_interface
-          path: src/hector_transmission_interface
+          repository: tu-darmstadt-ros-pkg/hector_controller_spawner
+          path: src/hector_controller_spawner
       - uses: actions/checkout@v4
         with:
           path: src/repo

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -60,6 +60,14 @@ jobs:
           path: src/hector_controller_spawner
       - uses: actions/checkout@v4
         with:
+          repository: tu-darmstadt-ros-pkg/hector_testing_utils
+          path: src/hector_testing_utils
+      - uses: actions/checkout@v4
+        with:
+          repository: tu-darmstadt-ros-pkg/hector_ros_controllers
+          path: src/hector_ros_controllers
+      - uses: actions/checkout@v4
+        with:
           path: src/repo
       - name: rosdep
         run: |

--- a/README.md
+++ b/README.md
@@ -207,7 +207,10 @@ falls below a configured threshold. The vibration can be muted temporarily via a
 - `cell_voltage_fields` (string list): Field paths (e.g., `["cell_voltages_battery1_mv", "cell_voltages_battery2_mv"]`)
   containing cell voltage values or arrays to evaluate.
 - `low_cell_threshold` (double): Cell voltage threshold to trigger vibration. Default: `3500.0`.
-- `vibration_intensity` (double): Rumble intensity in `[0.0, 1.0]`. Default: `0.8`.
+- `vibration_pattern.on_durations_sec` (double array): Pulse durations in seconds. Default: `[0.2, 0.2]`.
+- `vibration_pattern.off_durations_sec` (double array): Break durations after each pulse in seconds. Default: `[0.2, 5.0]`.
+- `vibration_pattern.intensity` (double): Rumble intensity in `[0.0, 1.0]`. Default: `0.8`.
+- `vibration_pattern.cycle` (bool): If `true`, repeats the pattern forever. Default: `true`.
 - `mute_duration_sec` (double): How long the mute lasts after pressing `mute`. Default: `300.0` seconds (5 minutes).
 - `ignore_zero_voltage` (bool): If `true`, zero voltage readings are ignored (useful for unpopulated cells). Default: `true`.
 - `ignore_nan_voltage` (bool): If `true`, NaN voltage readings are ignored. Default: `true`.

--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -28,5 +28,9 @@
                 - "cell_voltages_battery1_mv"
                 - "cell_voltages_battery2_mv"
             low_cell_threshold: 3500.0
-            vibration_intensity: 0.8
+            vibration_pattern:
+                on_durations_sec: [0.5, 0.5]
+                off_durations_sec: [0.25, 5.0]
+                intensity: 1.0
+                cycle: true
             mute_duration_sec: 300.0

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -1,6 +1,7 @@
 #ifndef HECTOR_GAMEPAD_MANAGER_HECTOR_GAMEPAD_MANAGER_HPP
 #define HECTOR_GAMEPAD_MANAGER_HECTOR_GAMEPAD_MANAGER_HPP
 
+#include "hector_gamepad_plugin_interface/feedback_manager.hpp"
 #include "hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp"
 
 #include <pluginlib/class_loader.hpp>
@@ -77,7 +78,11 @@ private:
   // stores the plugins present in the active configuration file
   std::vector<std::shared_ptr<GamepadFunctionPlugin>> active_plugins_;
 
+  // Blackboard for inter-plugin communication and function arguments
   std::shared_ptr<hector_gamepad_plugin_interface::Blackboard> blackboard_;
+
+  // Feedback manager for handling vibration patterns
+  std::shared_ptr<hector_gamepad_plugin_interface::FeedbackManager> feedback_manager_;
 
   // Deadzone to consider an axis as pressed
   static constexpr float AXIS_DEADZONE = 0.5;

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -7,7 +7,6 @@
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
-#include <sensor_msgs/msg/joy_feedback.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <yaml-cpp/yaml.h>
 
@@ -47,7 +46,6 @@ private:
   rclcpp::Node::SharedPtr ocs_ns_node_;
 
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
-  rclcpp::Publisher<sensor_msgs::msg::JoyFeedback>::SharedPtr joy_feedback_publisher_;
 
   // Publish active configuration -> visualization in user interface
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_config_publisher_;

--- a/hector_gamepad_manager/test/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/test/config/athena_plugin_config.yaml
@@ -32,5 +32,9 @@
                 - "cell_voltages_battery1_mv"
                 - "cell_voltages_battery2_mv"
             low_cell_threshold: 3300.0
-            vibration_intensity: 0.8
+            vibration_pattern:
+                on_durations_sec: [0.2, 0.2]
+                off_durations_sec: [0.2, 5.0]
+                intensity: 0.8
+                cycle: true
             mute_duration_sec: 300.0

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/battery_monitor_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/battery_monitor_plugin.hpp
@@ -49,6 +49,5 @@ private:
   bool low_voltage_detected_{ false };
   rclcpp::Time muted_until_{ 0, 0, RCL_ROS_TIME };
   std::string vibration_pattern_id_;
-  std::shared_ptr<hector_gamepad_plugin_interface::VibrationPattern> vibration_pattern_;
 };
 } // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/battery_monitor_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/battery_monitor_plugin.hpp
@@ -3,6 +3,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp>
+#include <hector_gamepad_plugin_interface/vibration_pattern.hpp>
 #include <hector_ros2_utils/parameters/reconfigurable_parameter.hpp>
 #include <ros_babel_fish/babel_fish.hpp>
 #include <vector>
@@ -19,12 +20,9 @@ public:
   void handleRelease( const std::string &function, const std::string &id ) override { }
   void handleAxis( const std::string &function, const std::string &id, double value ) override { }
 
-  void update() override { }
-
   void activate() override;
   void deactivate() override;
-
-  double getVibrationFeedback() override;
+  void update() override;
 
 private:
   void trySubscribe();
@@ -37,13 +35,11 @@ private:
   rclcpp::TimerBase::SharedPtr subscription_timer_;
 
   hector::ParameterSubscription low_cell_threshold_param_;
-  hector::ParameterSubscription vibration_intensity_param_;
   hector::ParameterSubscription mute_duration_param_;
   hector::ParameterSubscription ignore_zero_voltage_param_;
   hector::ParameterSubscription ignore_nan_voltage_param_;
 
   double low_cell_threshold_{ 3300.0 };
-  double vibration_intensity_{ 0.8 };
   double mute_duration_sec_{ 300.0 }; // default to 5 minutes
   bool ignore_zero_voltage_{ true };
   bool ignore_nan_voltage_{ true };
@@ -52,5 +48,7 @@ private:
 
   bool low_voltage_detected_{ false };
   rclcpp::Time muted_until_{ 0, 0, RCL_ROS_TIME };
+  std::string vibration_pattern_id_;
+  std::shared_ptr<hector_gamepad_plugin_interface::VibrationPattern> vibration_pattern_;
 };
 } // namespace hector_gamepad_manager_plugins

--- a/hector_gamepad_manager_plugins/src/battery_monitor_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/battery_monitor_plugin.cpp
@@ -92,11 +92,9 @@ void BatteryMonitorPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   pattern_defaults.off_durations_sec = { 0.2, 5.0 };
   pattern_defaults.intensity = 0.8;
   pattern_defaults.cycle = true;
-  vibration_pattern_ = std::make_shared<hector_gamepad_plugin_interface::VibrationPattern>();
-  vibration_pattern_->configure( node, ns + ".vibration_pattern", pattern_defaults );
   vibration_pattern_id_ = ns + ".low_voltage";
   if ( feedback_manager_ ) {
-    feedback_manager_->registerVibrationPattern( vibration_pattern_id_, vibration_pattern_ );
+    feedback_manager_->createVibrationPattern( vibration_pattern_id_, pattern_defaults );
     feedback_manager_->setPatternActive( vibration_pattern_id_, false );
   }
 

--- a/hector_gamepad_manager_plugins/src/battery_monitor_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/battery_monitor_plugin.cpp
@@ -140,8 +140,8 @@ void BatteryMonitorPlugin::trySubscribe()
       subscription_timer_.reset();
     }
   } else {
-    RCLCPP_INFO_THROTTLE( node_->get_logger(), *node_->get_clock(), 5000,
-                          "[BatteryMonitor] Waiting for topic '%s'...", topic_name.c_str() );
+    RCLCPP_DEBUG_THROTTLE( node_->get_logger(), *node_->get_clock(), 5000,
+                           "[BatteryMonitor] Waiting for topic '%s'...", topic_name.c_str() );
   }
 }
 

--- a/hector_gamepad_plugin_interface/CMakeLists.txt
+++ b/hector_gamepad_plugin_interface/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcl_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(backward_ros REQUIRED)
 # Header-only interface target
@@ -23,7 +24,8 @@ target_include_directories(
   INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include>")
 target_link_libraries(${PROJECT_NAME} INTERFACE yaml-cpp)
-ament_target_dependencies(${PROJECT_NAME} INTERFACE rclcpp rcl_interfaces)
+ament_target_dependencies(${PROJECT_NAME} INTERFACE rclcpp rcl_interfaces
+                          sensor_msgs)
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -54,7 +56,21 @@ if(BUILD_TESTING)
     target_compile_options(test_blackboard_yaml PRIVATE -Wall -Wextra
                                                         -Wpedantic)
   endif()
+  ament_add_gtest(test_vibration_pattern test/test_vibration_pattern.cpp)
+  if(TARGET test_vibration_pattern)
+    target_link_libraries(test_vibration_pattern ${PROJECT_NAME})
+    target_compile_features(test_vibration_pattern PRIVATE cxx_std_17)
+    target_compile_options(test_vibration_pattern PRIVATE -Wall -Wextra
+                                                          -Wpedantic)
+  endif()
+  ament_add_gtest(test_feedback_manager test/test_feedback_manager.cpp)
+  if(TARGET test_feedback_manager)
+    target_link_libraries(test_feedback_manager ${PROJECT_NAME})
+    target_compile_features(test_feedback_manager PRIVATE cxx_std_17)
+    target_compile_options(test_feedback_manager PRIVATE -Wall -Wextra
+                                                         -Wpedantic)
+  endif()
 endif()
 
-ament_export_dependencies(rclcpp rcl_interfaces yaml-cpp)
+ament_export_dependencies(rclcpp rcl_interfaces sensor_msgs yaml-cpp)
 ament_package()

--- a/hector_gamepad_plugin_interface/CMakeLists.txt
+++ b/hector_gamepad_plugin_interface/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(backward_ros REQUIRED)
 # Header-only interface target
@@ -22,6 +23,7 @@ target_include_directories(
   INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include>")
 target_link_libraries(${PROJECT_NAME} INTERFACE yaml-cpp)
+ament_target_dependencies(${PROJECT_NAME} INTERFACE rclcpp rcl_interfaces)
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -54,5 +56,5 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-ament_export_dependencies(yaml-cpp)
+ament_export_dependencies(rclcpp rcl_interfaces yaml-cpp)
 ament_package()

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/feedback_manager.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/feedback_manager.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy_feedback.hpp>
 
 #include "vibration_pattern.hpp"
 
@@ -14,6 +18,31 @@ class FeedbackManager
 public:
   using PatternPtr = std::shared_ptr<VibrationPattern>;
 
+  /**
+   * @brief Initialize feedback publishing on a periodic timer.
+   *
+   * @param node ROS node used to create publisher and timer.
+   * @param topic Joy feedback topic to publish to.
+   * @param publish_rate_hz Publish frequency (min 10 Hz).
+   */
+  void initialize( const rclcpp::Node::SharedPtr &node,
+                   const std::string &topic = "joy/set_feedback", double publish_rate_hz = 10.0 )
+  {
+    if ( !node ) {
+      return;
+    }
+    node_ = node;
+    publish_rate_hz_ = std::max( publish_rate_hz, 10.0 );
+    joy_feedback_publisher_ =
+        node_->create_publisher<sensor_msgs::msg::JoyFeedback>( topic, rclcpp::QoS( 1 ) );
+    const auto period = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::duration<double>( 1.0 / publish_rate_hz_ ) );
+    publish_timer_ = node_->create_wall_timer( period, [this]() { publishFeedback(); } );
+  }
+
+  /**
+   * @brief Register a vibration pattern by id.
+   */
   void registerVibrationPattern( const std::string &id, const PatternPtr &pattern )
   {
     if ( !pattern ) {
@@ -22,8 +51,14 @@ public:
     vibration_patterns_[id] = pattern;
   }
 
+  /**
+   * @brief Unregister a vibration pattern by id.
+   */
   void unregisterVibrationPattern( const std::string &id ) { vibration_patterns_.erase( id ); }
 
+  /**
+   * @brief Enable or disable a registered pattern.
+   */
   void setPatternActive( const std::string &id, const bool active )
   {
     auto it = vibration_patterns_.find( id );
@@ -37,6 +72,11 @@ public:
     }
   }
 
+  /**
+   * @brief Compute the max intensity across all active patterns.
+   *
+   * @return Intensity in [0.0, 1.0], 0.0 once when stopping, or -1.0 if fully idle.
+   */
   double getVibrationIntensity()
   {
     double intensity = 0.0;
@@ -60,6 +100,9 @@ public:
     return intensity;
   }
 
+  /**
+   * @brief Check whether a specific pattern is active.
+   */
   bool isActive( const std::string &id ) const
   {
     auto it = vibration_patterns_.find( id );
@@ -73,7 +116,30 @@ public:
   }
 
 private:
+  /**
+   * @brief Publish the current feedback value if active or just transitioned to idle.
+   */
+  void publishFeedback()
+  {
+    if ( !joy_feedback_publisher_ ) {
+      return;
+    }
+    const double intensity = getVibrationIntensity();
+    if ( intensity < 0.0 ) {
+      return;
+    }
+    sensor_msgs::msg::JoyFeedback feedback;
+    feedback.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
+    feedback.id = 0; // all motors
+    feedback.intensity = intensity;
+    joy_feedback_publisher_->publish( feedback );
+  }
+
   std::unordered_map<std::string, std::weak_ptr<VibrationPattern>> vibration_patterns_;
   double last_intensity_{ 0.0 };
+  double publish_rate_hz_{ 10.0 };
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Publisher<sensor_msgs::msg::JoyFeedback>::SharedPtr joy_feedback_publisher_;
+  rclcpp::TimerBase::SharedPtr publish_timer_;
 };
 } // namespace hector_gamepad_plugin_interface

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/feedback_manager.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/feedback_manager.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "vibration_pattern.hpp"
+
+namespace hector_gamepad_plugin_interface
+{
+class FeedbackManager
+{
+public:
+  using PatternPtr = std::shared_ptr<VibrationPattern>;
+
+  void registerVibrationPattern( const std::string &id, const PatternPtr &pattern )
+  {
+    if ( !pattern ) {
+      return;
+    }
+    vibration_patterns_[id] = pattern;
+  }
+
+  void unregisterVibrationPattern( const std::string &id ) { vibration_patterns_.erase( id ); }
+
+  void setPatternActive( const std::string &id, const bool active )
+  {
+    auto it = vibration_patterns_.find( id );
+    if ( it == vibration_patterns_.end() ) {
+      return;
+    }
+    if ( auto pattern = it->second.lock() ) {
+      pattern->setActive( active );
+    } else {
+      vibration_patterns_.erase( it );
+    }
+  }
+
+  double getVibrationIntensity()
+  {
+    double intensity = 0.0;
+    for ( auto it = vibration_patterns_.begin(); it != vibration_patterns_.end(); ) {
+      auto pattern = it->second.lock();
+      if ( !pattern ) {
+        it = vibration_patterns_.erase( it );
+        continue;
+      }
+      intensity = std::max( intensity, pattern->getIntensityNow() );
+      ++it;
+    }
+    if ( intensity <= 0.0 && last_intensity_ > 0.0 ) {
+      last_intensity_ = intensity;
+      return 0.0;
+    }
+    last_intensity_ = intensity;
+    if ( intensity <= 0.0 ) {
+      return -1.0;
+    }
+    return intensity;
+  }
+
+  bool isActive( const std::string &id ) const
+  {
+    auto it = vibration_patterns_.find( id );
+    if ( it == vibration_patterns_.end() ) {
+      return false;
+    }
+    if ( auto pattern = it->second.lock() ) {
+      return pattern->isActive();
+    }
+    return false;
+  }
+
+private:
+  std::unordered_map<std::string, std::weak_ptr<VibrationPattern>> vibration_patterns_;
+  double last_intensity_{ 0.0 };
+};
+} // namespace hector_gamepad_plugin_interface

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
@@ -2,6 +2,7 @@
 #define HECTOR_GAMEPAD_MANAGER_GAMEPAD_FUNCTION_PLUGIN_HPP
 
 #include "blackboard.hpp"
+#include "feedback_manager.hpp"
 #include <algorithm>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
@@ -15,10 +16,12 @@ public:
   virtual ~GamepadFunctionPlugin() = default;
 
   void initializePlugin( const rclcpp::Node::SharedPtr &node, const std::string &plugin_id,
-                         std::shared_ptr<Blackboard> blackboard )
+                         std::shared_ptr<Blackboard> blackboard,
+                         std::shared_ptr<FeedbackManager> feedback_manager )
   {
     node_ = node;
     blackboard_ = blackboard;
+    feedback_manager_ = feedback_manager;
     setPluginId( plugin_id );
     initialize( node );
   }
@@ -96,13 +99,6 @@ public:
     (void)function;
     (void)id;
   }
-
-  /**
-   * @brief Get vibration feedback value for the gamepad.
-   *
-   * @return Vibration feedback value (0.0 to 1.0).
-   */
-  virtual double getVibrationFeedback() { return 0.0; }
 
   /**
    *
@@ -211,6 +207,7 @@ protected:
   std::string plugin_name_;
   std::string plugin_namespace_;
   std::shared_ptr<Blackboard> blackboard_;
+  std::shared_ptr<FeedbackManager> feedback_manager_;
 };
 } // namespace hector_gamepad_plugin_interface
 

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/vibration_pattern.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/vibration_pattern.hpp
@@ -105,10 +105,7 @@ public:
       return 0.0;
     }
 
-    double elapsed = ( node_->now() - start_time_ ).seconds();
-    if ( elapsed < 0.0 ) {
-      elapsed = 0.0;
-    }
+    double elapsed = std::max( ( node_->now() - start_time_ ).seconds(), 0.0 );
     if ( cycle_ ) {
       elapsed = std::fmod( elapsed, total_duration_sec_ );
     } else if ( elapsed >= total_duration_sec_ ) {

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/vibration_pattern.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/vibration_pattern.hpp
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace hector_gamepad_plugin_interface
+{
+
+struct VibrationPatternDefaults {
+  std::vector<double> on_durations_sec;
+  std::vector<double> off_durations_sec;
+  double intensity{ 1.0 };
+  bool cycle{ true };
+};
+
+class VibrationPattern
+{
+public:
+  void configure( const rclcpp::Node::SharedPtr &node, const std::string &param_ns,
+                  const VibrationPatternDefaults &defaults = VibrationPatternDefaults() )
+  {
+    node_ = node;
+    param_ns_ = param_ns;
+    on_durations_sec_ = defaults.on_durations_sec;
+    off_durations_sec_ = defaults.off_durations_sec;
+    intensity_ = defaults.intensity;
+    cycle_ = defaults.cycle;
+
+    declareOrGet( param_ns_ + ".on_durations_sec", on_durations_sec_ );
+    declareOrGet( param_ns_ + ".off_durations_sec", off_durations_sec_ );
+    declareOrGet( param_ns_ + ".intensity", intensity_ );
+    declareOrGet( param_ns_ + ".cycle", cycle_ );
+
+    normalizeDurations();
+    updateTotalDuration();
+    reset();
+
+    param_callback_ = node_->add_on_set_parameters_callback(
+        [this]( const std::vector<rclcpp::Parameter> &params ) {
+          return onParameterUpdate( params );
+        } );
+  }
+
+  void reset()
+  {
+    if ( !node_ ) {
+      return;
+    }
+    start_time_ = node_->now();
+  }
+
+  void setActive( const bool active )
+  {
+    if ( active && !active_ ) {
+      reset();
+    }
+    active_ = active;
+  }
+
+  bool isActive() const { return active_; }
+
+  double getIntensityNow() const
+  {
+    if ( !active_ || !node_ ) {
+      return 0.0;
+    }
+    if ( total_duration_sec_ <= 0.0 || on_durations_sec_.empty() ) {
+      return 0.0;
+    }
+
+    double elapsed = ( node_->now() - start_time_ ).seconds();
+    if ( elapsed < 0.0 ) {
+      elapsed = 0.0;
+    }
+    if ( cycle_ ) {
+      elapsed = std::fmod( elapsed, total_duration_sec_ );
+    } else if ( elapsed >= total_duration_sec_ ) {
+      return 0.0;
+    }
+
+    double cursor = 0.0;
+    const size_t pulse_count = on_durations_sec_.size();
+    for ( size_t i = 0; i < pulse_count; ++i ) {
+      const double on_duration = on_durations_sec_[i];
+      const double off_duration = ( i < off_durations_sec_.size() ) ? off_durations_sec_[i] : 0.0;
+      if ( elapsed < cursor + on_duration ) {
+        return std::clamp( intensity_, 0.0, 1.0 );
+      }
+      cursor += on_duration;
+      if ( elapsed < cursor + off_duration ) {
+        return 0.0;
+      }
+      cursor += off_duration;
+    }
+    return 0.0;
+  }
+
+private:
+  template<typename T>
+  void declareOrGet( const std::string &name, T &value )
+  {
+    if ( !node_->has_parameter( name ) ) {
+      node_->declare_parameter<T>( name, value );
+    }
+    node_->get_parameter( name, value );
+  }
+
+  void normalizeDurations()
+  {
+    for ( auto &value : on_durations_sec_ ) { value = std::max( 0.0, value ); }
+    for ( auto &value : off_durations_sec_ ) { value = std::max( 0.0, value ); }
+  }
+
+  void updateTotalDuration()
+  {
+    total_duration_sec_ = 0.0;
+    const size_t pulse_count = on_durations_sec_.size();
+    for ( size_t i = 0; i < pulse_count; ++i ) {
+      total_duration_sec_ += on_durations_sec_[i];
+      if ( i < off_durations_sec_.size() ) {
+        total_duration_sec_ += off_durations_sec_[i];
+      }
+    }
+  }
+
+  rcl_interfaces::msg::SetParametersResult
+  onParameterUpdate( const std::vector<rclcpp::Parameter> &params )
+  {
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+
+    bool updated = false;
+    std::vector<double> next_on_durations = on_durations_sec_;
+    std::vector<double> next_off_durations = off_durations_sec_;
+    double next_intensity = intensity_;
+    bool next_cycle = cycle_;
+
+    for ( const auto &param : params ) {
+      const auto &name = param.get_name();
+      if ( name == param_ns_ + ".on_durations_sec" ) {
+        if ( param.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY ) {
+          result.successful = false;
+          result.reason = "on_durations_sec must be a double array";
+          return result;
+        }
+        next_on_durations = param.as_double_array();
+        updated = true;
+      } else if ( name == param_ns_ + ".off_durations_sec" ) {
+        if ( param.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY ) {
+          result.successful = false;
+          result.reason = "off_durations_sec must be a double array";
+          return result;
+        }
+        next_off_durations = param.as_double_array();
+        updated = true;
+      } else if ( name == param_ns_ + ".intensity" ) {
+        if ( param.get_type() != rclcpp::ParameterType::PARAMETER_DOUBLE ) {
+          result.successful = false;
+          result.reason = "intensity must be a double";
+          return result;
+        }
+        next_intensity = param.as_double();
+        if ( next_intensity < 0.0 || next_intensity > 1.0 ) {
+          result.successful = false;
+          result.reason = "intensity must be in [0.0, 1.0]";
+          return result;
+        }
+        updated = true;
+      } else if ( name == param_ns_ + ".cycle" ) {
+        if ( param.get_type() != rclcpp::ParameterType::PARAMETER_BOOL ) {
+          result.successful = false;
+          result.reason = "cycle must be a bool";
+          return result;
+        }
+        next_cycle = param.as_bool();
+        updated = true;
+      }
+    }
+
+    if ( updated ) {
+      on_durations_sec_ = std::move( next_on_durations );
+      off_durations_sec_ = std::move( next_off_durations );
+      intensity_ = next_intensity;
+      cycle_ = next_cycle;
+      normalizeDurations();
+      updateTotalDuration();
+    }
+
+    return result;
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  std::string param_ns_;
+  std::vector<double> on_durations_sec_;
+  std::vector<double> off_durations_sec_;
+  double intensity_{ 1.0 };
+  bool cycle_{ true };
+  bool active_{ false };
+  double total_duration_sec_{ 0.0 };
+  rclcpp::Time start_time_{ 0, 0, RCL_ROS_TIME };
+  rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr param_callback_;
+};
+
+} // namespace hector_gamepad_plugin_interface

--- a/hector_gamepad_plugin_interface/package.xml
+++ b/hector_gamepad_plugin_interface/package.xml
@@ -14,6 +14,7 @@
   <depend>backward_ros</depend>
   <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>yaml-cpp</depend>
 

--- a/hector_gamepad_plugin_interface/package.xml
+++ b/hector_gamepad_plugin_interface/package.xml
@@ -10,6 +10,9 @@
   <author email="aljoscha.schmidt@tu-darmstadt.de">Aljoscha Schmidt</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>backward_ros</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>yaml-cpp</depend>

--- a/hector_gamepad_plugin_interface/test/test_feedback_manager.cpp
+++ b/hector_gamepad_plugin_interface/test/test_feedback_manager.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <hector_gamepad_plugin_interface/feedback_manager.hpp>
+#include <hector_gamepad_plugin_interface/vibration_pattern.hpp>
+
+using hector_gamepad_plugin_interface::FeedbackManager;
+using hector_gamepad_plugin_interface::VibrationPattern;
+using hector_gamepad_plugin_interface::VibrationPatternDefaults;
+
+namespace
+{
+std::shared_ptr<rclcpp::Node> makeNode( const std::string &name_prefix )
+{
+  static int counter = 0;
+  return std::make_shared<rclcpp::Node>( name_prefix + "_" + std::to_string( counter++ ) );
+}
+
+bool waitForCondition( const std::function<bool()> &condition,
+                       const std::chrono::milliseconds timeout )
+{
+  const auto start = std::chrono::steady_clock::now();
+  while ( std::chrono::steady_clock::now() - start < timeout ) {
+    if ( condition() ) {
+      return true;
+    }
+    std::this_thread::sleep_for( std::chrono::milliseconds( 2 ) );
+  }
+  return false;
+}
+} // namespace
+
+TEST( FeedbackManager, EmitsSingleZeroAfterStopping )
+{
+  auto node = makeNode( "feedback_manager" );
+  auto pattern = std::make_shared<VibrationPattern>();
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.03 };
+  defaults.off_durations_sec = { 0.02 };
+  defaults.intensity = 0.4;
+  defaults.cycle = false;
+  pattern->configure( node, "pattern.feedback", defaults );
+
+  FeedbackManager manager;
+  manager.registerVibrationPattern( "pattern", pattern );
+  manager.setPatternActive( "pattern", true );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return manager.getVibrationIntensity() > 0.0; },
+                                 std::chrono::milliseconds( 80 ) ) );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return manager.getVibrationIntensity() == 0.0; },
+                                 std::chrono::milliseconds( 120 ) ) );
+
+  EXPECT_DOUBLE_EQ( manager.getVibrationIntensity(), -1.0 );
+}
+
+TEST( FeedbackManager, InactivePatternsReturnIdle )
+{
+  auto node = makeNode( "feedback_inactive" );
+  auto pattern = std::make_shared<VibrationPattern>();
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.02 };
+  defaults.off_durations_sec = { 0.01 };
+  defaults.intensity = 0.2;
+  defaults.cycle = true;
+  pattern->configure( node, "pattern.inactive", defaults );
+
+  FeedbackManager manager;
+  manager.registerVibrationPattern( "pattern", pattern );
+  manager.setPatternActive( "pattern", false );
+
+  EXPECT_DOUBLE_EQ( manager.getVibrationIntensity(), -1.0 );
+}
+
+int main( int argc, char **argv )
+{
+  rclcpp::init( argc, argv );
+  ::testing::InitGoogleTest( &argc, argv );
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/hector_gamepad_plugin_interface/test/test_feedback_manager.cpp
+++ b/hector_gamepad_plugin_interface/test/test_feedback_manager.cpp
@@ -40,16 +40,15 @@ bool waitForCondition( const std::function<bool()> &condition,
 TEST( FeedbackManager, EmitsSingleZeroAfterStopping )
 {
   auto node = makeNode( "feedback_manager" );
-  auto pattern = std::make_shared<VibrationPattern>();
   VibrationPatternDefaults defaults;
   defaults.on_durations_sec = { 0.03 };
   defaults.off_durations_sec = { 0.02 };
   defaults.intensity = 0.4;
   defaults.cycle = false;
-  pattern->configure( node, "pattern.feedback", defaults );
 
   FeedbackManager manager;
-  manager.registerVibrationPattern( "pattern", pattern );
+  manager.initialize( node );
+  manager.createVibrationPattern( "pattern", defaults );
   manager.setPatternActive( "pattern", true );
 
   EXPECT_TRUE( waitForCondition( [&]() { return manager.getVibrationIntensity() > 0.0; },
@@ -64,16 +63,15 @@ TEST( FeedbackManager, EmitsSingleZeroAfterStopping )
 TEST( FeedbackManager, InactivePatternsReturnIdle )
 {
   auto node = makeNode( "feedback_inactive" );
-  auto pattern = std::make_shared<VibrationPattern>();
   VibrationPatternDefaults defaults;
   defaults.on_durations_sec = { 0.02 };
   defaults.off_durations_sec = { 0.01 };
   defaults.intensity = 0.2;
   defaults.cycle = true;
-  pattern->configure( node, "pattern.inactive", defaults );
 
   FeedbackManager manager;
-  manager.registerVibrationPattern( "pattern", pattern );
+  manager.initialize( node );
+  manager.createVibrationPattern( "pattern", defaults );
   manager.setPatternActive( "pattern", false );
 
   EXPECT_DOUBLE_EQ( manager.getVibrationIntensity(), -1.0 );

--- a/hector_gamepad_plugin_interface/test/test_vibration_pattern.cpp
+++ b/hector_gamepad_plugin_interface/test/test_vibration_pattern.cpp
@@ -1,0 +1,139 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <hector_gamepad_plugin_interface/vibration_pattern.hpp>
+
+using hector_gamepad_plugin_interface::VibrationPattern;
+using hector_gamepad_plugin_interface::VibrationPatternDefaults;
+
+namespace
+{
+std::shared_ptr<rclcpp::Node> makeNode( const std::string &name_prefix )
+{
+  static int counter = 0;
+  return std::make_shared<rclcpp::Node>( name_prefix + "_" + std::to_string( counter++ ) );
+}
+
+bool waitForCondition( const std::function<bool()> &condition,
+                       const std::chrono::milliseconds timeout )
+{
+  const auto start = std::chrono::steady_clock::now();
+  while ( std::chrono::steady_clock::now() - start < timeout ) {
+    if ( condition() ) {
+      return true;
+    }
+    std::this_thread::sleep_for( std::chrono::milliseconds( 2 ) );
+  }
+  return false;
+}
+} // namespace
+
+TEST( VibrationPattern, InactiveOrUnconfiguredReturnsZero )
+{
+  VibrationPattern pattern;
+  EXPECT_DOUBLE_EQ( pattern.getIntensityNow(), 0.0 );
+
+  auto node = makeNode( "vibration_unconfigured" );
+  pattern.configure( node, "pattern.inactive" );
+  pattern.setActive( false );
+  EXPECT_DOUBLE_EQ( pattern.getIntensityNow(), 0.0 );
+}
+
+TEST( VibrationPattern, SinglePulseNonCyclingStopsAfterDuration )
+{
+  auto node = makeNode( "vibration_single_pulse" );
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.05 };
+  defaults.off_durations_sec = { 0.02 };
+  defaults.intensity = 0.7;
+  defaults.cycle = false;
+
+  VibrationPattern pattern;
+  pattern.configure( node, "pattern.single_pulse", defaults );
+  pattern.setActive( true );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() > 0.1; },
+                                 std::chrono::milliseconds( 80 ) ) );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() <= 0.0; },
+                                 std::chrono::milliseconds( 120 ) ) );
+}
+
+TEST( VibrationPattern, CyclingPatternRepeats )
+{
+  auto node = makeNode( "vibration_cycle" );
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.02 };
+  defaults.off_durations_sec = { 0.02 };
+  defaults.intensity = 0.6;
+  defaults.cycle = true;
+
+  VibrationPattern pattern;
+  pattern.configure( node, "pattern.cycle", defaults );
+  pattern.setActive( true );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() > 0.1; },
+                                 std::chrono::milliseconds( 80 ) ) );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() <= 0.0; },
+                                 std::chrono::milliseconds( 80 ) ) );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() > 0.1; },
+                                 std::chrono::milliseconds( 120 ) ) );
+}
+
+TEST( VibrationPattern, ReactivatingResetsTiming )
+{
+  auto node = makeNode( "vibration_reactivate" );
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.03 };
+  defaults.off_durations_sec = { 0.02 };
+  defaults.intensity = 0.9;
+  defaults.cycle = false;
+
+  VibrationPattern pattern;
+  pattern.configure( node, "pattern.reactivate", defaults );
+  pattern.setActive( true );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() <= 0.0; },
+                                 std::chrono::milliseconds( 120 ) ) );
+
+  pattern.setActive( false );
+  pattern.setActive( true );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() > 0.1; },
+                                 std::chrono::milliseconds( 80 ) ) );
+}
+
+TEST( VibrationPattern, RejectsInvalidParameterUpdates )
+{
+  auto node = makeNode( "vibration_params" );
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.01 };
+  defaults.off_durations_sec = { 0.01 };
+  defaults.intensity = 0.5;
+  defaults.cycle = true;
+
+  VibrationPattern pattern;
+  pattern.configure( node, "pattern.params", defaults );
+
+  auto results = node->set_parameters( { rclcpp::Parameter( "pattern.params.intensity", 2.0 ) } );
+  ASSERT_EQ( results.size(), 1u );
+  EXPECT_FALSE( results[0].successful );
+}
+
+int main( int argc, char **argv )
+{
+  rclcpp::init( argc, argv );
+  ::testing::InitGoogleTest( &argc, argv );
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
Add configurable vibration patterns to the feedback manager so plugins can register reusable, time-based rumble sequences. Patterns are now parameterized (on/off durations, intensity, cycle) via plugin config and support runtime reconfiguration. Battery monitor plugin wires in a default low-voltage pattern.