### PR TITLE
reduced flipper up speed

### DIFF
--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -8,7 +8,8 @@
     flipper_plugin:
       flipper_back_factor: 1.0
       flipper_front_factor: 1.0
-      speed: 0.75        # max of slowest dynamixel motors
+      button_speed_scaling: 0.75
+      speed: 0.75        # max of slowest flipper (FR)
       standard_controller: flipper_trajectory_controller
       teleop_controller:
       - flipper_velocity_controller

--- a/hector_gamepad_manager/test/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/test/config/athena_plugin_config.yaml
@@ -12,6 +12,7 @@
     flipper_plugin:
       flipper_back_factor: 1.0
       flipper_front_factor: 1.0
+      button_speed_scaling: 1.0
       speed: 1.5      # max of dynamixel motors
       standard_controller: flipper_trajectory_controller
       teleop_controller:

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -33,10 +33,12 @@ private:
   hector::ParameterSubscription speed_sub_;
   hector::ParameterSubscription flipper_front_factor_param_sub_;
   hector::ParameterSubscription flipper_back_factor_param_sub_;
+  hector::ParameterSubscription button_speed_scaling_param_sub_;
 
   double speed_ = 0.0;
   double flipper_front_factor_ = 0.0;
   double flipper_back_factor_ = 0.0;
+  double button_speed_scaling_ = 0.75;
 
   bool individual_front_flipper_mode_ = false;
   bool individual_back_flipper_mode_ = false;

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -23,6 +23,11 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
       "Flipper Back Factor", hector::ParameterOptions<double>().onValidate( []( const auto &value ) {
         return value > 0.0;
       } ) );
+  button_speed_scaling_param_sub_ = hector::createReconfigurableParameter(
+      node, plugin_namespace + ".button_speed_scaling", std::ref( button_speed_scaling_ ),
+      "Button Speed Scaling", hector::ParameterOptions<double>().onValidate( []( const auto &value ) {
+        return value >= 0.0 && value <= 1.0;
+      } ) );
 
   // Setup static parameters
   node_->declare_parameters<std::string>(
@@ -62,9 +67,9 @@ void FlipperPlugin::handlePress( const std::string &function, const std::string 
   }
 
   if ( individual_front_flipper_mode_ || individual_back_flipper_mode_ )
-    handleIndividualFlipperControlInput( 1, true, function );
+    handleIndividualFlipperControlInput( button_speed_scaling_, true, function );
   else
-    handleBasicControlInput( 1, true, function );
+    handleBasicControlInput( button_speed_scaling_, true, function );
 }
 
 void FlipperPlugin::handleRelease( const std::string &function, const std::string &id )


### PR DESCRIPTION
## Summary
Introduced a `button_speed_scaling` that allows for reducing the speed of the flipper_up movement. Currently, the flippers move up with their max speed.

Also reduced the overall speed of the flippers to match the slowest flipper actuator (front right).