### PR TITLE
Add double-press button mapping and flipper upright/sync actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .idea/
 .vscode/
 build/
+install/
+log/
+.codex
+.codex/
 cmake-build-*/
 **/__pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
   hooks:
   - id: cppcheck
     name: Cppcheck
-    entry: bash -c "cppcheck --force --quiet --inline-suppr --error-exitcode=1 --language=c++ $(find . -type d -name 'cmake-build-*' -prune -false -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.c' -o -name '*.cc')"
+    entry: bash -c "cppcheck --force --quiet --inline-suppr --error-exitcode=1 --language=c++ $(find . -type d \\( -name 'cmake-build-*' -o -name 'build' -o -name 'install' -o -name 'log' \\) -prune -false -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.c' -o -name '*.cc')"
     language: system
     files: \.(cpp|cc|hpp|h)$
     pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ This plugin is used to drive the robot using a gamepad.
 
 - `drive`: Forward and backward movement of the robot. Default button: (Left joystick up/down)
 - `steer`: Left and right steering of the robot. Default button: (Left joystick left/right)
-- `fast`: Fast driving mode. Default button: (A)
-- `slow`: Slow driving mode. Default button: (X)
+- `fast`: Fast driving mode. Default button: (Y)
+- `slow`: Slow driving mode. Default button: (A)
+
+> **Default-mapping change:** `fast` and `slow` were swapped from (A/X) to (Y/A) when the per-event button format landed, freeing up B and X for the FlipperPlugin's individual-control modes and double-press sync actions.
 
 ## FlipperPlugin
 
@@ -159,8 +161,10 @@ This plugin is used to steer the robot flippers using a gamepad. It sends veloci
 Running drive-to-upright and sync actions are **automatically pre-empted on the controller side** as soon as a manual velocity command arrives for the affected flipper group (e.g., pressing LB/RB or moving LT/RT). The plugin itself does not cancel goals; the `vel_to_pos_controller` aborts the active action when it sees an incoming velocity command.
 
 #### Mode Toggles
-- `individual_front_flipper_control_mode`: Toggle individual front flipper steering. Default button: (B)
-- `individual_back_flipper_control_mode`: Toggle individual back flipper steering. Default button: (X)
+- `individual_front_flipper_control_mode`: Toggle individual front flipper steering. Default button: (B, single-press)
+- `individual_back_flipper_control_mode`: Toggle individual back flipper steering. Default button: (X, single-press)
+
+> **Note on B/X and LB/RB:** these buttons each serve two functions via the per-event format. A single press toggles individual front/back control mode (B/X) or starts a velocity command (LB/RB); a double press triggers the corresponding sync or drive-to-upright action. Because `on_double_press` is configured on these buttons, single presses incur a small dispatch delay equal to `double_press_window_sec` (default 0.25s).
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Args are placed at the top level of the button entry (not under individual event
 > **Note:** Buttons without `on_double_press` are dispatched immediately with zero added latency.
 > The basic format (`plugin` + `function`) is still fully supported and behaves identically to before.
 
+#### Caveats
+
+- **Latency on double-press buttons.** Configuring `on_double_press` delays single-press dispatch by up to `double_press_window_sec` (default 0.25s) so the manager can wait for a possible second press. Avoid `on_double_press` on time-critical actions (e.g. emergency stops).
+- **Per-event args are not supported.** A button has one `args:` block shared by all events. `args:` placed under `on_double_press`, `on_hold`, or `on_release` are ignored with a warning at load time.
+- **`double_press_window_sec` is read once at startup**, not dynamically reconfigurable.
+- **Plugin state contract.** For buttons with `on_double_press`, the manager dispatches `handlePress`/`handleHold`/`handleRelease` directly and bypasses the base class's `handleButton`. Plugin subclasses must not assume `GamepadFunctionPlugin::button_states_` reflects the physical state of double-press-configured buttons.
+
 ---
 
 ## Joy Callback
@@ -160,11 +167,11 @@ This plugin is used to steer the robot flippers using a gamepad. It sends veloci
 
 Running drive-to-upright and sync actions are **automatically pre-empted on the controller side** as soon as a manual velocity command arrives for the affected flipper group (e.g., pressing LB/RB or moving LT/RT). The plugin itself does not cancel goals; the `vel_to_pos_controller` aborts the active action when it sees an incoming velocity command.
 
-#### Mode Toggles
-- `individual_front_flipper_control_mode`: Toggle individual front flipper steering. Default button: (B, single-press)
-- `individual_back_flipper_control_mode`: Toggle individual back flipper steering. Default button: (X, single-press)
+#### Individual Control Modes
+- `individual_front_flipper_control_mode`: Hold to enable individual front flipper steering; release to return to paired control. Default button: (B, single-press)
+- `individual_back_flipper_control_mode`: Hold to enable individual back flipper steering; release to return to paired control. Default button: (X, single-press)
 
-> **Note on B/X and LB/RB:** these buttons each serve two functions via the per-event format. A single press toggles individual front/back control mode (B/X) or starts a velocity command (LB/RB); a double press triggers the corresponding sync or drive-to-upright action. Because `on_double_press` is configured on these buttons, single presses incur a small dispatch delay equal to `double_press_window_sec` (default 0.25s).
+> **Note on B/X and LB/RB:** these buttons each serve two functions via the per-event format. Holding B/X enables individual front/back control mode until released; pressing and holding LB/RB drives a velocity command. A double press triggers the corresponding sync or drive-to-upright action. Because `on_double_press` is configured on these buttons, single-press dispatch is delayed by `double_press_window_sec` (default 0.25s) — a quick tap therefore enables the mode (or velocity command) only briefly before its paired release fires.
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This plugin is used to drive the robot using a gamepad.
 
 ## FlipperPlugin
 
-This plugin is used to steer the robot flippers using a gamepad. It sends velocity commands for manual control and uses action clients to trigger drive-to-upright and sync operations on the `vel_to_pos_controller`.
+This plugin is used to steer the robot flippers using a gamepad. It sends velocity commands for manual control and uses action clients to trigger drive-to-upright and sync operations on the `flipper_velocity_to_position_controller`.
 
 ### Functions
 
@@ -165,7 +165,7 @@ This plugin is used to steer the robot flippers using a gamepad. It sends veloci
 - `sync_back_flippers`: Sync back flipper pair to their average position. Default trigger: double-press (X)
 - `sync_all_flippers`: Sync all flipper groups simultaneously. (Not mapped by default)
 
-Running drive-to-upright and sync actions are **automatically pre-empted on the controller side** as soon as a manual velocity command arrives for the affected flipper group (e.g., pressing LB/RB or moving LT/RT). The plugin itself does not cancel goals; the `vel_to_pos_controller` aborts the active action when it sees an incoming velocity command.
+Running drive-to-upright and sync actions are **automatically pre-empted on the controller side** as soon as a manual velocity command arrives for the affected flipper group (e.g., pressing LB/RB or moving LT/RT). The plugin itself does not cancel goals; the `flipper_velocity_to_position_controller` aborts the active action when it sees an incoming velocity command.
 
 #### Individual Control Modes
 - `individual_front_flipper_control_mode`: Hold to enable individual front flipper steering; release to return to paired control. Default button: (B, single-press)
@@ -176,8 +176,8 @@ Running drive-to-upright and sync actions are **automatically pre-empted on the 
 ### Parameters
 
 - `command_topic` (string): Topic to publish velocity commands. Default: `flipper_velocity_controller/commands`
-- `drive_flipper_action` (string): Action server for drive-to-target. Default: `/<robot_ns>/vel_to_pos_controller/drive_flipper_group`
-- `sync_flipper_action` (string): Action server for sync. Default: `/<robot_ns>/vel_to_pos_controller/sync_flipper_group`
+- `drive_flipper_action` (string): Action server for drive-to-target. Default: `/<robot_ns>/flipper_velocity_to_position_controller/drive_flipper_group`
+- `sync_flipper_action` (string): Action server for sync. Default: `/<robot_ns>/flipper_velocity_to_position_controller/sync_flipper_group`
 
 ## Manipulation Plugin
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Each configuration file maps **buttons/axes** to **plugin functions**.
 Functions can now include **parameters** via the `args` field. These parameters are stored in the shared **blackboard**
 and are uniquely namespaced, so you can reuse the same function in different or even within the same config.
 
-#### Example: Driving Configuration
+#### Example: Driving Configuration (basic format)
 
 ```yaml
 axes:
@@ -60,6 +60,38 @@ buttons:
       group: "arm_group"
       pose: "folded"
 ```
+
+#### Per-Event Button Mapping
+
+Buttons support an extended format that maps different functions to different input events.
+This enables features like **double-press detection** without requiring plugin-side changes.
+
+```yaml
+buttons:
+  4: # Button LB
+    plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
+    on_press:
+      function: "flipper_back_up"
+    on_double_press:
+      function: "flipper_back_upright"
+    on_hold:                          # optional, defaults to on_press function
+      function: "flipper_back_up"
+    on_release:                       # optional, defaults to on_press function
+      function: "flipper_back_up"
+    args:                             # shared by all events on this button
+      some_param: 1.0
+```
+
+Available event types:
+- **`on_press`**: Triggered on button press (single press). This is equivalent to the basic `function` field.
+- **`on_double_press`**: Triggered when the button is pressed twice within a short time window. The window length is configurable via the `double_press_window_sec` ROS parameter (default 0.25s). When configured, `on_press` is delayed until the window expires to avoid false triggers.
+- **`on_hold`**: Triggered repeatedly while the button is held down. Defaults to the `on_press` function if omitted.
+- **`on_release`**: Triggered when the button is released. Defaults to the `on_press` function if omitted.
+
+Args are placed at the top level of the button entry (not under individual events) and are shared by all events on that button. As a convenience, an `args` block under `on_press` is also accepted and treated identically. Per-event `args` under `on_double_press`, `on_hold`, or `on_release` are not currently distinguishable on the plugin read side and will be ignored with a warning.
+
+> **Note:** Buttons without `on_double_press` are dispatched immediately with zero added latency.
+> The basic format (`plugin` + `function`) is still fully supported and behaves identically to before.
 
 ---
 
@@ -105,14 +137,36 @@ This plugin is used to drive the robot using a gamepad.
 
 ## FlipperPlugin
 
-This plugin is used to steer the robot flippers using a gamepad.
+This plugin is used to steer the robot flippers using a gamepad. It sends velocity commands for manual control and uses action clients to trigger drive-to-upright and sync operations on the `vel_to_pos_controller`.
 
 ### Functions
 
-- `front_flippers_up`: Rotate front flippers upwards (counterclockwise). Default button: (RB)
-- `front_flippers_down`: Rotate front flippers downwards (clockwise). Default button: (LT)
-- `back_flippers_up`: Rotate back flippers upwards (clockwise). Default button: (LB)
-- `back_flippers_down`: Rotate back flippers downwards (counterclockwise). Default button: (LT)
+#### Velocity Control
+- `flipper_front_up`: Rotate front flippers upwards (counterclockwise). Default button: (RB)
+- `flipper_front_down`: Rotate front flippers downwards (clockwise). Default button: (RT)
+- `flipper_back_up`: Rotate back flippers upwards (clockwise). Default button: (LB)
+- `flipper_back_down`: Rotate back flippers downwards (counterclockwise). Default button: (LT)
+
+#### Drive to Upright (via `DriveFlipperGroup` action)
+- `flipper_front_upright`: Drive front flippers to upright position. Default trigger: double-press (RB)
+- `flipper_back_upright`: Drive back flippers to upright position. Default trigger: double-press (LB)
+
+#### Sync Flippers (via `SyncFlipperGroup` action)
+- `sync_front_flippers`: Sync front flipper pair to their average position. Default trigger: double-press (B)
+- `sync_back_flippers`: Sync back flipper pair to their average position. Default trigger: double-press (X)
+- `sync_all_flippers`: Sync all flipper groups simultaneously. (Not mapped by default)
+
+Running drive-to-upright and sync actions are **automatically pre-empted on the controller side** as soon as a manual velocity command arrives for the affected flipper group (e.g., pressing LB/RB or moving LT/RT). The plugin itself does not cancel goals; the `vel_to_pos_controller` aborts the active action when it sees an incoming velocity command.
+
+#### Mode Toggles
+- `individual_front_flipper_control_mode`: Toggle individual front flipper steering. Default button: (B)
+- `individual_back_flipper_control_mode`: Toggle individual back flipper steering. Default button: (X)
+
+### Parameters
+
+- `command_topic` (string): Topic to publish velocity commands. Default: `flipper_velocity_controller/commands`
+- `drive_flipper_action` (string): Action server for drive-to-target. Default: `/<robot_ns>/vel_to_pos_controller/drive_flipper_group`
+- `sync_flipper_action` (string): Action server for sync. Default: `/<robot_ns>/vel_to_pos_controller/sync_flipper_group`
 
 ## Manipulation Plugin
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ buttons:
 ```
 
 Available event types:
-- **`on_press`**: Triggered on button press (single press). This is equivalent to the basic `function` field.
+- **`on_press`** *(required)*: Triggered on button press (single press). This is equivalent to the basic `function` field. It is also the fallback target for `on_hold`/`on_release` and the dispatch target on a single tap when `on_double_press` is configured, so a new-format mapping without `on_press` is rejected at load time.
 - **`on_double_press`**: Triggered when the button is pressed twice within a short time window. The window length is configurable via the `double_press_window_sec` ROS parameter (default 0.25s). When configured, `on_press` is delayed until the window expires to avoid false triggers.
 - **`on_hold`**: Triggered repeatedly while the button is held down. Defaults to the `on_press` function if omitted.
 - **`on_release`**: Triggered when the button is released. Defaults to the `on_press` function if omitted.

--- a/hector_gamepad_manager/CMakeLists.txt
+++ b/hector_gamepad_manager/CMakeLists.txt
@@ -59,8 +59,12 @@ if(BUILD_TESTING)
 
   # 1. Create the GTest/GMock executable
   ament_add_gmock(
-    ${PROJECT_NAME}_test test/main.cpp test/test_hector_gamepad_manager.cpp
-    test/test_hector_gamepad_manager_internal.cpp)
+    ${PROJECT_NAME}_test
+    test/main.cpp
+    test/test_hector_gamepad_manager.cpp
+    test/test_hector_gamepad_manager_internal.cpp
+    test/test_hector_gamepad_manager_double_press.cpp
+    test/test_hector_gamepad_manager_malformed.cpp)
 
   # 1. Link against the Test Doubles
   target_link_libraries(${PROJECT_NAME}_test

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -34,27 +34,39 @@ axes:
 buttons:
   0: # Button A
     plugin: hector_gamepad_manager_plugins::DrivePlugin
-    function: fast
+    function: slow
 
   1: # Button B
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
-    function: individual_back_flipper_control_mode
+    on_press:
+      function: individual_front_flipper_control_mode
+    on_double_press:
+      function: sync_front_flippers
 
   2: # Button X
-    plugin: hector_gamepad_manager_plugins::DrivePlugin
-    function: slow
+    plugin: hector_gamepad_manager_plugins::FlipperPlugin
+    on_press:
+      function: individual_back_flipper_control_mode
+    on_double_press:
+      function: sync_back_flippers
 
   3: # Button Y
-    plugin: hector_gamepad_manager_plugins::FlipperPlugin
-    function: individual_front_flipper_control_mode
+    plugin: hector_gamepad_manager_plugins::DrivePlugin
+    function: fast
 
   4: # Button LB
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
-    function: flipper_back_up
+    on_press:
+      function: flipper_back_up
+    on_double_press:
+      function: flipper_back_upright
 
   5: # Button RB
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
-    function: flipper_front_up
+    on_press:
+      function: flipper_front_up
+    on_double_press:
+      function: flipper_front_upright
 
   6: # Button Back
     plugin: ''

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -21,13 +21,33 @@ public:
   explicit HectorGamepadManager( const rclcpp::Node::SharedPtr &node );
 
 private:
-  // Struct to store the mapping of a button or axis to a function of a plugin
+  // Struct to store the mapping of an axis to a function of a plugin
   struct FunctionMapping {
     // Name of the plugin
     std::shared_ptr<GamepadFunctionPlugin> plugin;
 
     // Name of the function
     std::string function_name;
+  };
+
+  // Struct to store the mapping of a button to plugin functions per event type
+  struct ButtonFunctionMapping {
+    std::shared_ptr<GamepadFunctionPlugin> plugin;
+
+    std::string on_press;        // function called on initial press
+    std::string on_double_press; // function called on double press (empty = disabled)
+    std::string on_hold;         // function called while held (empty = uses on_press)
+    std::string on_release;      // function called on release (empty = uses on_press)
+
+    bool hasDoublePress() const { return !on_double_press.empty(); }
+  };
+
+  // Per-button state for double-press detection
+  struct ButtonTracker {
+    bool pressed = false;          // current physical state
+    bool press_dispatched = false; // was on_press already sent?
+    bool awaiting_double_press = false;
+    rclcpp::Time last_press_time{ 0, 0, RCL_ROS_TIME };
   };
 
   // Struct to store the inputs from the gamepad
@@ -39,7 +59,7 @@ private:
   };
 
   struct GamepadConfig {
-    std::unordered_map<int, FunctionMapping> button_mappings;
+    std::unordered_map<int, ButtonFunctionMapping> button_mappings;
     std::unordered_map<int, FunctionMapping> axis_mappings;
   };
 
@@ -89,6 +109,13 @@ private:
   // Controller Orchestrator for activating controllers
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
 
+  // Per-button trackers for double-press detection
+  std::unordered_map<int, ButtonTracker> button_trackers_;
+
+  // Time window for double-press detection (seconds), set from the
+  // `double_press_window_sec` ROS parameter (default 0.25).
+  double double_press_window_sec_;
+
   // Deadzone to consider an axis as pressed
   static constexpr float AXIS_DEADZONE = 0.5;
 
@@ -130,9 +157,15 @@ private:
    * @param mappings The mappings to be initialized.
    * @return True if the mappings were initialized successfully, false otherwise.
    */
+  bool initButtonMappings( const YAML::Node &config, const std::string &config_name,
+                           std::unordered_map<int, ButtonFunctionMapping> &mappings );
+
   bool initMappings( const YAML::Node &config, const std::string &type,
                      const std::string &config_name,
                      std::unordered_map<int, FunctionMapping> &mappings );
+
+  // Load the named plugin into plugins_ if not already present. Returns false on failure.
+  bool ensurePluginLoaded( const std::string &plugin_name );
 
   /**
    * @brief Activates all plugins present in the given config

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -30,7 +30,7 @@ private:
     std::string function_name;
   };
 
-  // Struct to store the mapping of a button to plugin functions per event type
+  // For double-press buttons the manager bypasses handleButton and dispatches handlePress / handleHold / handleRelease directly, so plugins must not rely on button_states_ for them.
   struct ButtonFunctionMapping {
     std::shared_ptr<GamepadFunctionPlugin> plugin;
 
@@ -39,7 +39,7 @@ private:
     std::string on_hold;         // function called while held (empty = uses on_press)
     std::string on_release;      // function called on release (empty = uses on_press)
 
-    bool hasDoublePress() const { return !on_double_press.empty(); }
+    bool has_double_press() const { return !on_double_press.empty(); }
   };
 
   // Per-button state for double-press detection
@@ -112,8 +112,7 @@ private:
   // Per-button trackers for double-press detection
   std::unordered_map<int, ButtonTracker> button_trackers_;
 
-  // Time window for double-press detection (seconds), set from the
-  // `double_press_window_sec` ROS parameter (default 0.25).
+  // Double-press window in seconds (ROS param `double_press_window_sec`, default 0.25).
   double double_press_window_sec_;
 
   // Deadzone to consider an axis as pressed
@@ -177,6 +176,9 @@ private:
    * @brief Deactivates all plugins
    */
   void deactivatePlugins();
+
+  // Synthesize the events needed to bring plugins back to a "no button held" state for double-press buttons before a config switch or shutdown.
+  void flushPendingButtonState();
 
   /**
    * @brief Callback function for the joy topic.

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -168,18 +168,17 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
       if ( mapping["on_release"] && mapping["on_release"]["function"] )
         on_release = mapping["on_release"]["function"].as<std::string>();
 
-      if ( on_press.empty() && on_double_press.empty() ) {
+      // on_press is required: it is the dispatch target for the timeout-flush path
+      // (and the fallback for on_hold/on_release). Without it, a single press of a
+      // double-press-configured button would dispatch handlePress/handleRelease with
+      // an empty function name.
+      if ( on_press.empty() ) {
         RCLCPP_WARN( ocs_ns_node_->get_logger(),
-                     "Button %d in config '%s' has new-format mapping but no on_press or "
-                     "on_double_press function. Skipping.",
+                     "Button %d in config '%s' has new-format mapping but no on_press "
+                     "function. on_press is required (it is the fallback for on_hold/"
+                     "on_release and the dispatch target on a single press). Skipping.",
                      id, config_name.c_str() );
         continue;
-      }
-      if ( on_press.empty() && ( !on_hold.empty() || !on_release.empty() ) ) {
-        RCLCPP_WARN( ocs_ns_node_->get_logger(),
-                     "Button %d in config '%s' specifies on_hold/on_release but no on_press "
-                     "to fall back to; those events will not fire on a single press.",
-                     id, config_name.c_str() );
       }
 
       // Args are stored under one shared blackboard prefix per button, matching the legacy

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -105,6 +105,8 @@ bool HectorGamepadManager::switchConfig( const std::string &config_name )
     return true;
   RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Switching from config %s to config: %s",
                 active_config_.c_str(), config_name.c_str() );
+  // Must run before deactivatePlugins() and before active_config_ is reassigned.
+  flushPendingButtonState();
   deactivatePlugins();
   button_trackers_.clear();
   active_config_publisher_->publish( std_msgs::msg::String().set__data( config_name ) );
@@ -168,10 +170,7 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
       if ( mapping["on_release"] && mapping["on_release"]["function"] )
         on_release = mapping["on_release"]["function"].as<std::string>();
 
-      // on_press is required: it is the dispatch target for the timeout-flush path
-      // (and the fallback for on_hold/on_release). Without it, a single press of a
-      // double-press-configured button would dispatch handlePress/handleRelease with
-      // an empty function name.
+      // on_press is required as the timeout-flush dispatch target and on_hold/on_release fallback.
       if ( on_press.empty() ) {
         RCLCPP_WARN( ocs_ns_node_->get_logger(),
                      "Button %d in config '%s' has new-format mapping but no on_press "
@@ -181,11 +180,7 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
         continue;
       }
 
-      // Args are stored under one shared blackboard prefix per button, matching the legacy
-      // format that built-in plugins read via getConfigValueOr(id, key). All events on a button
-      // therefore share one args block — supplied either at top level (`args:`) or, as a
-      // convenience, under `on_press: { args: ... }`. Per-event args are not currently
-      // distinguishable on the read side; if both are given, top-level wins.
+      // All events on a button share one args block; per-event args are not distinguishable on the read side. Top-level wins over on_press/args fallback.
       const std::string blackboard_prefix = plugin_name + "_" + function_id;
       if ( mapping["args"] ) {
         blackboard_->set_from_yaml( mapping["args"], blackboard_prefix );
@@ -236,7 +231,9 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
       auto plugin_name = mapping["plugin"].as<std::string>();
       auto function = mapping["function"].as<std::string>();
       const std::string function_id = config_name + "_" + std::to_string( id );
-      blackboard_->set_from_yaml( mapping["args"], plugin_name + std::string( "_" ) + function_id );
+      if ( mapping["args"] ) {
+        blackboard_->set_from_yaml( mapping["args"], plugin_name + std::string( "_" ) + function_id );
+      }
 
       if ( !plugin_name.empty() && !function.empty() ) {
         if ( !ensurePluginLoaded( plugin_name ) )
@@ -280,7 +277,7 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
     auto &tracker = button_trackers_[button_id];
     const bool was_pressed = tracker.pressed;
 
-    if ( !mapping.hasDoublePress() ) {
+    if ( !mapping.has_double_press() ) {
       // No double-press configured → dispatch immediately via handleButton (original behavior)
       const std::string &function = mapping.on_press;
       mapping.plugin->handleButton( function, id, pressed );
@@ -289,14 +286,24 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
       const bool rising_edge = pressed && !was_pressed;
       const bool falling_edge = !pressed && was_pressed;
 
+      // Backward clock jumps (sim-time replay/reset) are treated as "window expired" so the press doesn't stay buffered forever.
+      const double raw_elapsed = ( now - tracker.last_press_time ).seconds();
+      const bool window_expired = raw_elapsed < 0.0 || raw_elapsed >= double_press_window_sec_;
+
       if ( rising_edge ) {
-        if ( tracker.awaiting_double_press &&
-             ( now - tracker.last_press_time ).seconds() < double_press_window_sec_ ) {
+        if ( tracker.awaiting_double_press && !window_expired ) {
           // Second press within window → double press detected
           tracker.awaiting_double_press = false;
           tracker.press_dispatched = true;
           mapping.plugin->handlePress( mapping.on_double_press, id );
         } else {
+          // Flush a stale buffered tap before overwriting last_press_time, otherwise the original press is silently dropped when no callback fired during the wait window.
+          if ( tracker.awaiting_double_press && window_expired ) {
+            mapping.plugin->handlePress( mapping.on_press, id );
+            const std::string &release_fn =
+                mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+            mapping.plugin->handleRelease( release_fn, id );
+          }
           // First press → start waiting for potential second press
           tracker.awaiting_double_press = true;
           tracker.last_press_time = now;
@@ -315,23 +322,22 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
           mapping.plugin->handleRelease( release_fn, id );
           tracker.press_dispatched = false;
         }
-        // Note: if awaiting_double_press, we keep waiting — the second press
-        // can arrive after the button is released
+        // If awaiting_double_press, keep waiting — the second press can still arrive after release.
       }
     }
 
     tracker.pressed = pressed;
   }
 
-  // Check for double-press timeouts: if we waited long enough without a second press,
-  // dispatch the buffered single press
+  // Flush buffered single presses whose double-press window has expired.
   for ( const auto &[button_id, mapping] : configs_[active_config_].button_mappings ) {
-    if ( !mapping.hasDoublePress() )
+    if ( !mapping.has_double_press() )
       continue;
 
     auto &tracker = button_trackers_[button_id];
-    if ( tracker.awaiting_double_press &&
-         ( now - tracker.last_press_time ).seconds() >= double_press_window_sec_ ) {
+    const double raw_elapsed = ( now - tracker.last_press_time ).seconds();
+    const bool window_expired = raw_elapsed < 0.0 || raw_elapsed >= double_press_window_sec_;
+    if ( tracker.awaiting_double_press && window_expired ) {
       tracker.awaiting_double_press = false;
       const std::string id = active_config_ + "_" + std::to_string( button_id );
       mapping.plugin->handlePress( mapping.on_press, id );
@@ -340,9 +346,7 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
         // Still held — let subsequent frames drive hold/release through the normal path.
         tracker.press_dispatched = true;
       } else {
-        // Quick tap: button was already released while we waited. Pair the delayed press with
-        // an immediate release so plugins that toggle state (velocity on/off, etc.) don't get
-        // stuck with a press that never closes.
+        // Quick tap: pair the delayed press with an immediate release so the plugin doesn't get stuck.
         const std::string &release_fn =
             mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
         mapping.plugin->handleRelease( release_fn, id );
@@ -400,6 +404,40 @@ void HectorGamepadManager::deactivatePlugins()
     }
   }
   active_plugins_.clear();
+}
+
+void HectorGamepadManager::flushPendingButtonState()
+{
+  // Operates on the OUTGOING config — must run before active_config_ is reassigned.
+  if ( active_config_.empty() )
+    return;
+  auto config_it = configs_.find( active_config_ );
+  if ( config_it == configs_.end() )
+    return;
+  const auto &button_mappings = config_it->second.button_mappings;
+
+  for ( auto &[button_id, tracker] : button_trackers_ ) {
+    auto mapping_it = button_mappings.find( button_id );
+    if ( mapping_it == button_mappings.end() )
+      continue;
+    const auto &mapping = mapping_it->second;
+    if ( !mapping.has_double_press() )
+      continue;
+
+    const std::string id = active_config_ + "_" + std::to_string( button_id );
+    const std::string &release_fn =
+        mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+
+    if ( tracker.press_dispatched ) {
+      mapping.plugin->handleRelease( release_fn, id );
+      tracker.press_dispatched = false;
+    } else if ( tracker.awaiting_double_press ) {
+      // Emit the same press+release pair the timeout-quick-tap path would have produced.
+      mapping.plugin->handlePress( mapping.on_press, id );
+      mapping.plugin->handleRelease( release_fn, id );
+    }
+    tracker.awaiting_double_press = false;
+  }
 }
 
 HectorGamepadManager::GamepadInputs

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -15,11 +15,13 @@ HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node 
   node->declare_parameter<std::string>( "config_directory", "config" );
   node->declare_parameter<std::string>( "robot_namespace", "athena" );
   node->declare_parameter<std::string>( "ocs_namespace", "ocs" );
+  node->declare_parameter<double>( "double_press_window_sec", 0.25 );
   const std::string config_switches_filename = node->get_parameter( "config_name" ).as_string();
 
   robot_namespace_ = node->get_parameter( "robot_namespace" ).as_string();
   ocs_namespace_ = node->get_parameter( "ocs_namespace" ).as_string();
   config_directory_ = node->get_parameter( "config_directory" ).as_string();
+  double_press_window_sec_ = node->get_parameter( "double_press_window_sec" ).as_double();
 
   // create subnodes: one for the OCS and one for the robot
   ocs_ns_node_ = node->create_sub_node( ocs_namespace_ );
@@ -80,7 +82,7 @@ bool HectorGamepadManager::loadConfig( const std::string &pkg_name, const std::s
     // Add empty mappings for the filename
     configs_[file_name] = GamepadConfig();
 
-    if ( !initMappings( config, "buttons", file_name, configs_[file_name].button_mappings ) ||
+    if ( !initButtonMappings( config, file_name, configs_[file_name].button_mappings ) ||
          !initMappings( config, "axes", file_name, configs_[file_name].axis_mappings ) ) {
       return false;
     }
@@ -104,9 +106,101 @@ bool HectorGamepadManager::switchConfig( const std::string &config_name )
   RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Switching from config %s to config: %s",
                 active_config_.c_str(), config_name.c_str() );
   deactivatePlugins();
+  button_trackers_.clear();
   active_config_publisher_->publish( std_msgs::msg::String().set__data( config_name ) );
   active_config_ = config_name;
   activatePlugins( config_name );
+  return true;
+}
+
+bool HectorGamepadManager::ensurePluginLoaded( const std::string &plugin_name )
+{
+  if ( plugins_.count( plugin_name ) != 0 )
+    return true;
+  try {
+    std::shared_ptr<GamepadFunctionPlugin> plugin =
+        plugin_loader_.createSharedInstance( plugin_name );
+    plugin->initializePlugin( robot_ns_node_, ocs_ns_node_, plugin_name, blackboard_,
+                              feedback_manager_, controller_orchestrator_ );
+    plugins_[plugin_name] = plugin;
+    RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
+    return true;
+  } catch ( const std::exception &e ) {
+    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "Failed to load plugin %s: %s", plugin_name.c_str(),
+                  e.what() );
+    return false;
+  }
+}
+
+bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
+                                               const std::string &config_name,
+                                               std::unordered_map<int, ButtonFunctionMapping> &mappings )
+{
+  if ( !config["buttons"] ) {
+    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "No buttons found in config file" );
+    return false;
+  }
+
+  for ( const auto &entry : config["buttons"] ) {
+    const int id = entry.first.as<int>();
+    const YAML::Node mapping = entry.second;
+
+    if ( !mapping["plugin"] )
+      continue;
+    auto plugin_name = mapping["plugin"].as<std::string>();
+    if ( plugin_name.empty() )
+      continue;
+
+    // Detect new format: presence of on_press, on_double_press, on_hold, or on_release sub-keys
+    const bool new_format = mapping["on_press"] || mapping["on_double_press"] ||
+                            mapping["on_hold"] || mapping["on_release"];
+
+    std::string on_press, on_double_press, on_hold, on_release;
+    const std::string function_id = config_name + "_" + std::to_string( id );
+
+    if ( new_format ) {
+      if ( mapping["on_press"] && mapping["on_press"]["function"] )
+        on_press = mapping["on_press"]["function"].as<std::string>();
+      if ( mapping["on_double_press"] && mapping["on_double_press"]["function"] )
+        on_double_press = mapping["on_double_press"]["function"].as<std::string>();
+      if ( mapping["on_hold"] && mapping["on_hold"]["function"] )
+        on_hold = mapping["on_hold"]["function"].as<std::string>();
+      if ( mapping["on_release"] && mapping["on_release"]["function"] )
+        on_release = mapping["on_release"]["function"].as<std::string>();
+
+      // Args are stored under one shared blackboard prefix per button, matching the legacy
+      // format that built-in plugins read via getConfigValueOr(id, key). All events on a button
+      // therefore share one args block — supplied either at top level (`args:`) or, as a
+      // convenience, under `on_press: { args: ... }`. Per-event args are not currently
+      // distinguishable on the read side; if both are given, top-level wins.
+      const std::string blackboard_prefix = plugin_name + "_" + function_id;
+      if ( mapping["args"] ) {
+        blackboard_->set_from_yaml( mapping["args"], blackboard_prefix );
+      } else if ( mapping["on_press"] && mapping["on_press"]["args"] ) {
+        blackboard_->set_from_yaml( mapping["on_press"]["args"], blackboard_prefix );
+      }
+      for ( const auto &event_key : { "on_double_press", "on_hold", "on_release" } ) {
+        if ( mapping[event_key] && mapping[event_key]["args"] ) {
+          RCLCPP_WARN( ocs_ns_node_->get_logger(),
+                       "Per-event args under '%s' on button %d are not supported and will be "
+                       "ignored. Move them to a top-level 'args:' block.",
+                       event_key, id );
+        }
+      }
+    } else {
+      // Legacy flat format: plugin + function at top level → treat as on_press
+      auto function = mapping["function"].as<std::string>();
+      if ( function.empty() )
+        continue;
+      on_press = function;
+      blackboard_->set_from_yaml( mapping["args"], plugin_name + "_" + function_id );
+    }
+
+    if ( !ensurePluginLoaded( plugin_name ) )
+      return false;
+
+    mappings[id] = { plugins_[plugin_name], on_press, on_double_press, on_hold, on_release };
+  }
   return true;
 }
 
@@ -118,28 +212,16 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
     for ( const auto &entry : config[type] ) {
       int id = entry.first.as<int>();
       const YAML::Node mapping = entry.second;
+      if ( !mapping["plugin"] || !mapping["function"] )
+        continue;
       auto plugin_name = mapping["plugin"].as<std::string>();
       auto function = mapping["function"].as<std::string>();
       const std::string function_id = config_name + "_" + std::to_string( id );
       blackboard_->set_from_yaml( mapping["args"], plugin_name + std::string( "_" ) + function_id );
 
       if ( !plugin_name.empty() && !function.empty() ) {
-
-        // make sure plugin is loaded
-        if ( plugins_.count( plugin_name ) == 0 ) {
-          try {
-            std::shared_ptr<GamepadFunctionPlugin> plugin =
-                plugin_loader_.createSharedInstance( plugin_name );
-            plugin->initializePlugin( robot_ns_node_, ocs_ns_node_, plugin_name, blackboard_,
-                                      feedback_manager_, controller_orchestrator_ );
-            plugins_[plugin_name] = plugin;
-            RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
-          } catch ( const std::exception &e ) {
-            RCLCPP_ERROR( ocs_ns_node_->get_logger(), "Failed to load plugin %s: %s",
-                          plugin_name.c_str(), e.what() );
-            return false;
-          }
-        }
+        if ( !ensurePluginLoaded( plugin_name ) )
+          return false;
         mappings[id] = { plugins_[plugin_name], function };
       }
     }
@@ -170,12 +252,72 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
   if ( handleConfigurationSwitches( inputs ) )
     return;
 
-  // Handle buttons
-  for ( const auto &button_mapping : configs_[active_config_].button_mappings ) {
-    const bool pressed = inputs.buttons[button_mapping.first];
-    const auto &action = button_mapping.second;
-    const std::string id = active_config_ + "_" + std::to_string( button_mapping.first );
-    button_mapping.second.plugin->handleButton( action.function_name, id, pressed );
+  const auto now = ocs_ns_node_->now();
+
+  // Handle buttons with double-press detection
+  for ( const auto &[button_id, mapping] : configs_[active_config_].button_mappings ) {
+    const bool pressed = inputs.buttons[button_id];
+    const std::string id = active_config_ + "_" + std::to_string( button_id );
+    auto &tracker = button_trackers_[button_id];
+    const bool was_pressed = tracker.pressed;
+
+    if ( !mapping.hasDoublePress() ) {
+      // No double-press configured → dispatch immediately via handleButton (original behavior)
+      const std::string &function = mapping.on_press;
+      mapping.plugin->handleButton( function, id, pressed );
+    } else {
+      // Double-press enabled → buffered dispatch
+      const bool rising_edge = pressed && !was_pressed;
+      const bool falling_edge = !pressed && was_pressed;
+
+      if ( rising_edge ) {
+        if ( tracker.awaiting_double_press &&
+             ( now - tracker.last_press_time ).seconds() < double_press_window_sec_ ) {
+          // Second press within window → double press detected
+          tracker.awaiting_double_press = false;
+          tracker.press_dispatched = true;
+          mapping.plugin->handlePress( mapping.on_double_press, id );
+        } else {
+          // First press → start waiting for potential second press
+          tracker.awaiting_double_press = true;
+          tracker.last_press_time = now;
+          tracker.press_dispatched = false;
+        }
+      } else if ( pressed && was_pressed ) {
+        // Held — only dispatch hold if press was already dispatched
+        if ( tracker.press_dispatched ) {
+          const std::string &hold_fn = mapping.on_hold.empty() ? mapping.on_press : mapping.on_hold;
+          mapping.plugin->handleHold( hold_fn, id );
+        }
+      } else if ( falling_edge ) {
+        if ( tracker.press_dispatched ) {
+          const std::string &release_fn =
+              mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+          mapping.plugin->handleRelease( release_fn, id );
+          tracker.press_dispatched = false;
+        }
+        // Note: if awaiting_double_press, we keep waiting — the second press
+        // can arrive after the button is released
+      }
+    }
+
+    tracker.pressed = pressed;
+  }
+
+  // Check for double-press timeouts: if we waited long enough without a second press,
+  // dispatch the buffered single press
+  for ( const auto &[button_id, mapping] : configs_[active_config_].button_mappings ) {
+    if ( !mapping.hasDoublePress() )
+      continue;
+
+    auto &tracker = button_trackers_[button_id];
+    if ( tracker.awaiting_double_press &&
+         ( now - tracker.last_press_time ).seconds() >= double_press_window_sec_ ) {
+      tracker.awaiting_double_press = false;
+      tracker.press_dispatched = true;
+      const std::string id = active_config_ + "_" + std::to_string( button_id );
+      mapping.plugin->handlePress( mapping.on_press, id );
+    }
   }
 
   // Handle axes

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -168,6 +168,20 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
       if ( mapping["on_release"] && mapping["on_release"]["function"] )
         on_release = mapping["on_release"]["function"].as<std::string>();
 
+      if ( on_press.empty() && on_double_press.empty() ) {
+        RCLCPP_WARN( ocs_ns_node_->get_logger(),
+                     "Button %d in config '%s' has new-format mapping but no on_press or "
+                     "on_double_press function. Skipping.",
+                     id, config_name.c_str() );
+        continue;
+      }
+      if ( on_press.empty() && ( !on_hold.empty() || !on_release.empty() ) ) {
+        RCLCPP_WARN( ocs_ns_node_->get_logger(),
+                     "Button %d in config '%s' specifies on_hold/on_release but no on_press "
+                     "to fall back to; those events will not fire on a single press.",
+                     id, config_name.c_str() );
+      }
+
       // Args are stored under one shared blackboard prefix per button, matching the legacy
       // format that built-in plugins read via getConfigValueOr(id, key). All events on a button
       // therefore share one args block — supplied either at top level (`args:`) or, as a
@@ -189,6 +203,12 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
       }
     } else {
       // Legacy flat format: plugin + function at top level → treat as on_press
+      if ( !mapping["function"] ) {
+        RCLCPP_WARN( ocs_ns_node_->get_logger(),
+                     "Button %d in config '%s' has 'plugin' but no 'function'. Skipping.", id,
+                     config_name.c_str() );
+        continue;
+      }
       auto function = mapping["function"].as<std::string>();
       if ( function.empty() )
         continue;
@@ -314,9 +334,21 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
     if ( tracker.awaiting_double_press &&
          ( now - tracker.last_press_time ).seconds() >= double_press_window_sec_ ) {
       tracker.awaiting_double_press = false;
-      tracker.press_dispatched = true;
       const std::string id = active_config_ + "_" + std::to_string( button_id );
       mapping.plugin->handlePress( mapping.on_press, id );
+
+      if ( tracker.pressed ) {
+        // Still held — let subsequent frames drive hold/release through the normal path.
+        tracker.press_dispatched = true;
+      } else {
+        // Quick tap: button was already released while we waited. Pair the delayed press with
+        // an immediate release so plugins that toggle state (velocity on/off, etc.) don't get
+        // stuck with a press that never closes.
+        const std::string &release_fn =
+            mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+        mapping.plugin->handleRelease( release_fn, id );
+        tracker.press_dispatched = false;
+      }
     }
   }
 

--- a/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
@@ -1,0 +1,48 @@
+# Test-only config exercising the per-event button format and double-press detection.
+axes:
+  0: {plugin: '', function: ''}
+  1: {plugin: '', function: ''}
+  2: {plugin: '', function: ''}
+  3: {plugin: '', function: ''}
+  4: {plugin: '', function: ''}
+  5: {plugin: '', function: ''}
+  6: {plugin: '', function: ''}
+  7: {plugin: '', function: ''}
+
+buttons:
+  # Button A: on_press + on_double_press, no custom hold/release (so they fall back to on_press)
+  0:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    on_press: {function: probe}
+    on_double_press: {function: probe_double}
+  # Button B: full set with distinct on_hold and on_release function names
+  1:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    on_press: {function: probe}
+    on_double_press: {function: probe_double}
+    on_hold: {function: probe_hold}
+    on_release: {function: probe_release}
+  2: {plugin: '', function: ''}
+  3: {plugin: '', function: ''}
+  4: {plugin: '', function: ''}
+  5: {plugin: '', function: ''}
+  # Buttons 6 & 7 reserved for config switches
+  6: {plugin: '', function: ''}
+  7: {plugin: '', function: ''}
+  8: {plugin: '', function: ''}
+  9: {plugin: '', function: ''}
+  10: {plugin: '', function: ''}
+  11: {plugin: '', function: ''}
+  12: {plugin: '', function: ''}
+  13: {plugin: '', function: ''}
+  14: {plugin: '', function: ''}
+  15: {plugin: '', function: ''}
+  16: {plugin: '', function: ''}
+  17: {plugin: '', function: ''}
+  18: {plugin: '', function: ''}
+  19: {plugin: '', function: ''}
+  20: {plugin: '', function: ''}
+  21: {plugin: '', function: ''}
+  22: {plugin: '', function: ''}
+  23: {plugin: '', function: ''}
+  24: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
@@ -22,7 +22,12 @@ buttons:
     on_double_press: {function: probe_double}
     on_hold: {function: probe_hold}
     on_release: {function: probe_release}
-  2: {plugin: '', function: ''}
+  # Button X: also double-press capable, with distinct function names so we can verify per-button
+  # tracker state is independent (interleaved presses on different buttons).
+  2:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    on_press: {function: probe2}
+    on_double_press: {function: probe2_double}
   3: {plugin: '', function: ''}
   4: {plugin: '', function: ''}
   5: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_alt.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_alt.yaml
@@ -1,0 +1,37 @@
+# Minimal alternate config used by config-switch tests. Only needs to be loadable.
+axes:
+  0: {plugin: '', function: ''}
+  1: {plugin: '', function: ''}
+  2: {plugin: '', function: ''}
+  3: {plugin: '', function: ''}
+  4: {plugin: '', function: ''}
+  5: {plugin: '', function: ''}
+  6: {plugin: '', function: ''}
+  7: {plugin: '', function: ''}
+
+buttons:
+  0: {plugin: '', function: ''}
+  1: {plugin: '', function: ''}
+  2: {plugin: '', function: ''}
+  3: {plugin: '', function: ''}
+  4: {plugin: '', function: ''}
+  5: {plugin: '', function: ''}
+  6: {plugin: '', function: ''}
+  7: {plugin: '', function: ''}
+  8: {plugin: '', function: ''}
+  9: {plugin: '', function: ''}
+  10: {plugin: '', function: ''}
+  11: {plugin: '', function: ''}
+  12: {plugin: '', function: ''}
+  13: {plugin: '', function: ''}
+  14: {plugin: '', function: ''}
+  15: {plugin: '', function: ''}
+  16: {plugin: '', function: ''}
+  17: {plugin: '', function: ''}
+  18: {plugin: '', function: ''}
+  19: {plugin: '', function: ''}
+  20: {plugin: '', function: ''}
+  21: {plugin: '', function: ''}
+  22: {plugin: '', function: ''}
+  23: {plugin: '', function: ''}
+  24: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_params.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    use_sim_time: true
+    config_name: manager_internal_double_press_switches
+    config_directory: test/config
+    robot_namespace: athena
+    ocs_namespace: ocs
+    double_press_window_sec: 0.25

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
@@ -1,0 +1,28 @@
+# Switches file that boots the double-press test config as default.
+default_config: manager_internal_double_press
+buttons:
+  0: {package: '', config: ''}
+  1: {package: '', config: ''}
+  2: {package: '', config: ''}
+  3: {package: '', config: ''}
+  4: {package: '', config: ''}
+  5: {package: '', config: ''}
+  6: {package: '', config: ''}
+  7: {package: hector_gamepad_manager, config: manager_internal_double_press}
+  8: {package: '', config: ''}
+  9: {package: '', config: ''}
+  10: {package: '', config: ''}
+  11: {package: '', config: ''}
+  12: {package: '', config: ''}
+  13: {package: '', config: ''}
+  14: {package: '', config: ''}
+  15: {package: '', config: ''}
+  16: {package: '', config: ''}
+  17: {package: '', config: ''}
+  18: {package: '', config: ''}
+  19: {package: '', config: ''}
+  20: {package: '', config: ''}
+  21: {package: '', config: ''}
+  22: {package: '', config: ''}
+  23: {package: '', config: ''}
+  24: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
@@ -7,8 +7,8 @@ buttons:
   3: {package: '', config: ''}
   4: {package: '', config: ''}
   5: {package: '', config: ''}
-  6: {package: '', config: ''}
-  7: {package: hector_gamepad_manager, config: manager_internal_double_press}
+  6: {package: hector_gamepad_manager, config: manager_internal_double_press}
+  7: {package: hector_gamepad_manager, config: manager_internal_double_press_alt}
   8: {package: '', config: ''}
   9: {package: '', config: ''}
   10: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
@@ -23,7 +23,11 @@ buttons:
   2:
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     function: probe
-  3: {plugin: '', function: ''}
+  # Button Y: new-format entry with on_double_press but no on_press — must be skipped because
+  # the timeout-flush path would otherwise dispatch handlePress("") on a single tap.
+  3:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    on_double_press: {function: probe_double}
   4: {plugin: '', function: ''}
   5: {plugin: '', function: ''}
   6: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
@@ -1,0 +1,47 @@
+# Test-only config that exercises malformed-entry handling. The manager should log warnings
+# and skip the bad entries rather than throwing or registering a broken mapping.
+axes:
+  0: {plugin: '', function: ''}
+  1: {plugin: '', function: ''}
+  2: {plugin: '', function: ''}
+  3: {plugin: '', function: ''}
+  4: {plugin: '', function: ''}
+  5: {plugin: '', function: ''}
+  6: {plugin: '', function: ''}
+  7: {plugin: '', function: ''}
+
+buttons:
+  # Button A: legacy-format entry with plugin: but no function: — must be skipped, not crash.
+  0:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+  # Button B: new-format entry with no on_press and only on_hold/on_release — must be skipped.
+  1:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    on_hold: {function: probe_hold}
+    on_release: {function: probe_release}
+  # Button X: a valid legacy entry, so the rest of the config still loads.
+  2:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    function: probe
+  3: {plugin: '', function: ''}
+  4: {plugin: '', function: ''}
+  5: {plugin: '', function: ''}
+  6: {plugin: '', function: ''}
+  7: {plugin: '', function: ''}
+  8: {plugin: '', function: ''}
+  9: {plugin: '', function: ''}
+  10: {plugin: '', function: ''}
+  11: {plugin: '', function: ''}
+  12: {plugin: '', function: ''}
+  13: {plugin: '', function: ''}
+  14: {plugin: '', function: ''}
+  15: {plugin: '', function: ''}
+  16: {plugin: '', function: ''}
+  17: {plugin: '', function: ''}
+  18: {plugin: '', function: ''}
+  19: {plugin: '', function: ''}
+  20: {plugin: '', function: ''}
+  21: {plugin: '', function: ''}
+  22: {plugin: '', function: ''}
+  23: {plugin: '', function: ''}
+  24: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed_params.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    config_name: manager_internal_malformed_switches
+    config_directory: test/config
+    robot_namespace: athena
+    ocs_namespace: ocs

--- a/hector_gamepad_manager/test/config/manager_internal_malformed_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed_switches.yaml
@@ -1,0 +1,28 @@
+# Switches file that boots the malformed test config as default.
+default_config: manager_internal_malformed
+buttons:
+  0: {package: '', config: ''}
+  1: {package: '', config: ''}
+  2: {package: '', config: ''}
+  3: {package: '', config: ''}
+  4: {package: '', config: ''}
+  5: {package: '', config: ''}
+  6: {package: '', config: ''}
+  7: {package: hector_gamepad_manager, config: manager_internal_malformed}
+  8: {package: '', config: ''}
+  9: {package: '', config: ''}
+  10: {package: '', config: ''}
+  11: {package: '', config: ''}
+  12: {package: '', config: ''}
+  13: {package: '', config: ''}
+  14: {package: '', config: ''}
+  15: {package: '', config: ''}
+  16: {package: '', config: ''}
+  17: {package: '', config: ''}
+  18: {package: '', config: ''}
+  19: {package: '', config: ''}
+  20: {package: '', config: ''}
+  21: {package: '', config: ''}
+  22: {package: '', config: ''}
+  23: {package: '', config: ''}
+  24: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_zero_window_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_zero_window_params.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    use_sim_time: true
+    config_name: manager_internal_double_press_switches
+    config_directory: test/config
+    robot_namespace: athena
+    ocs_namespace: ocs
+    double_press_window_sec: 0.0

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -238,3 +238,143 @@ TEST_F( HectorGamepadManagerDoublePressTest, CustomHoldAndReleaseFunctionNamesAr
   setButton( 1, 0 );
   sendJoy();
 }
+
+// Test G — Two buttons that both have on_double_press are pressed in interleaved fashion.
+// Button 0 and button 2 each have independent trackers; a press on one must not flush or
+// double-trigger the other.
+TEST_F( HectorGamepadManagerDoublePressTest, InterleavedDoublePressButtonsTrackIndependently )
+{
+  // Press button 0 (probe), then press button 2 (probe2) inside button 0's window. Neither
+  // should fire on_press yet (still inside their respective windows), and neither should ever
+  // fire on_double_press because each button has only seen a single press.
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_release_, publish( _ ) ).Times( 0 );
+
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+
+  advanceMs( 100 ); // still inside button 0's window
+
+  setButton( 2, 1 );
+  sendJoy();
+  setButton( 2, 0 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
+
+  // Advance past button 0's window (total 300ms since button 0's first press) but still inside
+  // button 2's window. Button 0 should flush as a single press+release; button 2 should not.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "probe2" ) ) ) )
+      .Times( 0 );
+  advanceMs( 200 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
+
+  // Now finish button 2 with a second press inside its window — must dispatch probe2_double, and
+  // must NOT re-dispatch any probe events on button 0.
+  EXPECT_CALL( *pub_probe_press_, publish( Field( &std_msgs::msg::String::data,
+                                                  HasSubstr( "press:probe2_double:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 0 );
+  setButton( 2, 1 );
+  sendJoy();
+}
+
+// Test H — Edge case: double_press_window_sec = 0 should disable buffering entirely. Buttons
+// configured with on_double_press still load, but on_press fires on the same frame as the
+// physical press (no waiting), and a second quick press just fires on_press again. on_double_press
+// is effectively unreachable when the window is 0 — but we must not deadlock or stuck-press.
+class HectorGamepadManagerZeroWindowTest : public ::testing::Test
+{
+protected:
+  rclcpp::NodeOptions opts_;
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<hector_gamepad_manager::HectorGamepadManager> manager_;
+  std::unique_ptr<rtest::TestClock> clock_;
+
+  std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Joy>> sub_joy_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_config_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_press_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_release_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_hold_;
+
+  sensor_msgs::msg::Joy joy_msg_;
+
+  static std::string paramsFilePath()
+  {
+    auto path = std::filesystem::path( __FILE__ ).parent_path() / "config" /
+                "manager_internal_zero_window_params.yaml";
+    return path.string();
+  }
+
+  void SetUp() override
+  {
+    opts_ = rclcpp::NodeOptions();
+    opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
+
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_zero_window_test", opts_ );
+    clock_ = std::make_unique<rtest::TestClock>( node_ );
+    manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
+
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    pub_probe_press_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
+    pub_probe_release_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/release" );
+    pub_probe_hold_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/hold" );
+
+    ASSERT_TRUE( sub_joy_ );
+    ASSERT_TRUE( pub_config_ );
+    ASSERT_TRUE( pub_probe_press_ );
+    ASSERT_TRUE( pub_probe_release_ );
+    ASSERT_TRUE( pub_probe_hold_ );
+
+    EXPECT_CALL( *pub_config_, publish( _ ) ).Times( AnyNumber() );
+
+    joy_msg_.axes = std::vector<float>( MAX_AXES, 0.0f );
+    joy_msg_.buttons = std::vector<int>( MAX_BUTTONS, 0 );
+    joy_msg_.axes[2] = 1.0f;
+    joy_msg_.axes[5] = 1.0f;
+  }
+
+  void setButton( int id, int value ) { joy_msg_.buttons[id] = value; }
+  void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
+};
+
+// With a zero window, a press of a double-press-configured button does not stick: on the same
+// frame the press is registered, the timeout already expired, so the press flushes immediately,
+// and a release on the next frame (after the button goes up) closes the cycle cleanly.
+TEST_F( HectorGamepadManagerZeroWindowTest, ZeroWindowFlushesPressImmediately )
+{
+  // Press → immediate flush (window already expired). The button is still held, so the timeout
+  // path leaves press_dispatched=true and no release fires yet.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_, publish( _ ) ).Times( 0 );
+  setButton( 0, 1 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
+
+  // Release fires when the button goes up.
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  setButton( 0, 0 );
+  sendJoy();
+}

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -1,0 +1,240 @@
+#include <gmock/gmock.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rtest/publisher_mock.hpp>
+#include <rtest/subscription_mock.hpp>
+#include <rtest/test_clock.hpp>
+
+#include <sensor_msgs/msg/joy.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <hector_gamepad_manager/hector_gamepad_manager.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::Field;
+using ::testing::HasSubstr;
+
+constexpr int MAX_BUTTONS = 25;
+constexpr int MAX_AXES = 8;
+
+class HectorGamepadManagerDoublePressTest : public ::testing::Test
+{
+protected:
+  rclcpp::NodeOptions opts_;
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<hector_gamepad_manager::HectorGamepadManager> manager_;
+  std::unique_ptr<rtest::TestClock> clock_;
+
+  std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Joy>> sub_joy_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_config_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_press_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_hold_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_release_;
+
+  sensor_msgs::msg::Joy joy_msg_;
+
+  static std::string paramsFilePath()
+  {
+    auto path = std::filesystem::path( __FILE__ ).parent_path() / "config" /
+                "manager_internal_double_press_params.yaml";
+    return path.string();
+  }
+
+  void SetUp() override
+  {
+    opts_ = rclcpp::NodeOptions();
+    opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
+
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_double_press_test", opts_ );
+    clock_ = std::make_unique<rtest::TestClock>( node_ );
+    manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
+
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    pub_probe_press_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
+    pub_probe_hold_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/hold" );
+    pub_probe_release_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/release" );
+
+    ASSERT_TRUE( sub_joy_ );
+    ASSERT_TRUE( pub_config_ );
+    ASSERT_TRUE( pub_probe_press_ );
+    ASSERT_TRUE( pub_probe_hold_ );
+    ASSERT_TRUE( pub_probe_release_ );
+
+    EXPECT_CALL( *pub_config_, publish( _ ) ).Times( AnyNumber() );
+
+    resetJoy();
+  }
+
+  void resetJoy()
+  {
+    joy_msg_.axes = std::vector<float>( MAX_AXES, 0.0f );
+    joy_msg_.buttons = std::vector<int>( MAX_BUTTONS, 0 );
+    joy_msg_.axes[2] = 1.0f;
+    joy_msg_.axes[5] = 1.0f;
+  }
+
+  void setButton( int id, int value ) { joy_msg_.buttons[id] = value; }
+
+  void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
+
+  void advanceMs( int64_t ms ) { clock_->advanceMs( ms ); }
+};
+
+// Test A — Quick tap with on_double_press configured: a press immediately followed by a release
+// must, after the double-press window expires, dispatch on_press AND a paired on_release.
+// Without the fix, on_release is never sent, leaving plugins stuck in the "pressed" state.
+TEST_F( HectorGamepadManagerDoublePressTest, QuickTapWithDoublePressDispatchesPressAndRelease )
+{
+  // No press/release/hold should fire while we are still inside the window.
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_release_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_hold_, publish( _ ) ).Times( 0 );
+
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_hold_.get() );
+
+  // Advance past the window — the buffered press should flush, paired with an immediate release.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_hold_, publish( _ ) ).Times( 0 );
+
+  advanceMs( 300 );
+  sendJoy();
+}
+
+// Test B — Two quick presses inside the window dispatch on_double_press only.
+TEST_F( HectorGamepadManagerDoublePressTest, DoublePressDispatchesDoublePressFunction )
+{
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  advanceMs( 100 ); // still inside window
+
+  // Second press within the window — on_double_press fires, on_press does NOT.
+  EXPECT_CALL( *pub_probe_press_, publish( Field( &std_msgs::msg::String::data,
+                                                  HasSubstr( "press:probe_double:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 0 );
+  setButton( 0, 1 );
+  sendJoy();
+}
+
+// Test C — A press flushed by timeout, then a second fresh press: each should fire as a single
+// press, never as a double-press.
+TEST_F( HectorGamepadManagerDoublePressTest, TwoPressesSeparatedByTimeoutAreBothSinglePresses )
+{
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 2 );
+  EXPECT_CALL( *pub_probe_press_, publish( Field( &std_msgs::msg::String::data,
+                                                  HasSubstr( "press:probe_double:" ) ) ) )
+      .Times( 0 );
+
+  // First press, release, wait past window — flushes as single press.
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+  advanceMs( 300 );
+  sendJoy();
+
+  // Second press, release, wait past window — also flushes as single press.
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+  advanceMs( 300 );
+  sendJoy();
+}
+
+// Test D — Holding the button across the window boundary: timeout flushes the press, subsequent
+// frames dispatch on_hold, and finally a release fires when the button goes up.
+TEST_F( HectorGamepadManagerDoublePressTest, HeldButtonAfterTimeoutGeneratesHoldsAndRelease )
+{
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  setButton( 0, 1 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  // Window expires while still held — press flushes, no release yet.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_hold_, publish( _ ) ).Times( 0 );
+  advanceMs( 300 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_hold_.get() );
+
+  // Subsequent frames with the button still held → hold (button 0 has no on_hold, so it falls
+  // back to on_press's function name "probe").
+  EXPECT_CALL( *pub_probe_hold_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "hold:probe:" ) ) ) )
+      .Times( 2 );
+  sendJoy();
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_hold_.get() );
+
+  // Release fires when the button finally goes up.
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  setButton( 0, 0 );
+  sendJoy();
+}
+
+// Test D2 — Same as D, but on a button with explicit on_hold/on_release function names. Verifies
+// the dispatched function name comes from the per-event YAML keys, not from on_press fallback.
+TEST_F( HectorGamepadManagerDoublePressTest, CustomHoldAndReleaseFunctionNamesAreDispatched )
+{
+  setButton( 1, 1 );
+  sendJoy();
+  advanceMs( 300 );
+
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  EXPECT_CALL( *pub_probe_hold_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "hold:probe_hold:" ) ) ) )
+      .Times( 1 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_hold_.get() );
+
+  EXPECT_CALL( *pub_probe_release_, publish( Field( &std_msgs::msg::String::data,
+                                                    HasSubstr( "release:probe_release:" ) ) ) )
+      .Times( 1 );
+  setButton( 1, 0 );
+  sendJoy();
+}

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -91,9 +91,7 @@ protected:
   void advanceMs( int64_t ms ) { clock_->advanceMs( ms ); }
 };
 
-// Test A — Quick tap with on_double_press configured: a press immediately followed by a release
-// must, after the double-press window expires, dispatch on_press AND a paired on_release.
-// Without the fix, on_release is never sent, leaving plugins stuck in the "pressed" state.
+// A quick tap on a double-press button must flush as press+release after the window expires.
 TEST_F( HectorGamepadManagerDoublePressTest, QuickTapWithDoublePressDispatchesPressAndRelease )
 {
   // No press/release/hold should fire while we are still inside the window.
@@ -146,8 +144,7 @@ TEST_F( HectorGamepadManagerDoublePressTest, DoublePressDispatchesDoublePressFun
   sendJoy();
 }
 
-// Test C — A press flushed by timeout, then a second fresh press: each should fire as a single
-// press, never as a double-press.
+// Two presses separated by a timeout each fire as single presses, never as double-press.
 TEST_F( HectorGamepadManagerDoublePressTest, TwoPressesSeparatedByTimeoutAreBothSinglePresses )
 {
   EXPECT_CALL( *pub_probe_press_,
@@ -174,8 +171,7 @@ TEST_F( HectorGamepadManagerDoublePressTest, TwoPressesSeparatedByTimeoutAreBoth
   sendJoy();
 }
 
-// Test D — Holding the button across the window boundary: timeout flushes the press, subsequent
-// frames dispatch on_hold, and finally a release fires when the button goes up.
+// Holding across the window: timeout flushes the press, then holds, then release on button-up.
 TEST_F( HectorGamepadManagerDoublePressTest, HeldButtonAfterTimeoutGeneratesHoldsAndRelease )
 {
   EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
@@ -195,8 +191,7 @@ TEST_F( HectorGamepadManagerDoublePressTest, HeldButtonAfterTimeoutGeneratesHold
   ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
   ::testing::Mock::VerifyAndClearExpectations( pub_probe_hold_.get() );
 
-  // Subsequent frames with the button still held → hold (button 0 has no on_hold, so it falls
-  // back to on_press's function name "probe").
+  // Button 0 has no on_hold so it falls back to on_press ("probe").
   EXPECT_CALL( *pub_probe_hold_,
                publish( Field( &std_msgs::msg::String::data, HasSubstr( "hold:probe:" ) ) ) )
       .Times( 2 );
@@ -212,8 +207,7 @@ TEST_F( HectorGamepadManagerDoublePressTest, HeldButtonAfterTimeoutGeneratesHold
   sendJoy();
 }
 
-// Test D2 — Same as D, but on a button with explicit on_hold/on_release function names. Verifies
-// the dispatched function name comes from the per-event YAML keys, not from on_press fallback.
+// Verifies hold/release dispatch uses per-event YAML function names, not the on_press fallback.
 TEST_F( HectorGamepadManagerDoublePressTest, CustomHoldAndReleaseFunctionNamesAreDispatched )
 {
   setButton( 1, 1 );
@@ -239,14 +233,10 @@ TEST_F( HectorGamepadManagerDoublePressTest, CustomHoldAndReleaseFunctionNamesAr
   sendJoy();
 }
 
-// Test G — Two buttons that both have on_double_press are pressed in interleaved fashion.
-// Button 0 and button 2 each have independent trackers; a press on one must not flush or
-// double-trigger the other.
+// Per-button trackers are independent: a press on one button must not flush the other.
 TEST_F( HectorGamepadManagerDoublePressTest, InterleavedDoublePressButtonsTrackIndependently )
 {
-  // Press button 0 (probe), then press button 2 (probe2) inside button 0's window. Neither
-  // should fire on_press yet (still inside their respective windows), and neither should ever
-  // fire on_double_press because each button has only seen a single press.
+  // Press button 0, then button 2 inside button 0's window. Neither fires yet.
   EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
   EXPECT_CALL( *pub_probe_release_, publish( _ ) ).Times( 0 );
 
@@ -264,8 +254,7 @@ TEST_F( HectorGamepadManagerDoublePressTest, InterleavedDoublePressButtonsTrackI
   ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
   ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
 
-  // Advance past button 0's window (total 300ms since button 0's first press) but still inside
-  // button 2's window. Button 0 should flush as a single press+release; button 2 should not.
+  // Past button 0's window but inside button 2's: button 0 flushes, button 2 does not.
   EXPECT_CALL( *pub_probe_press_,
                publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
       .Times( 1 );
@@ -280,8 +269,7 @@ TEST_F( HectorGamepadManagerDoublePressTest, InterleavedDoublePressButtonsTrackI
   ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
   ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
 
-  // Now finish button 2 with a second press inside its window — must dispatch probe2_double, and
-  // must NOT re-dispatch any probe events on button 0.
+  // Second press on button 2 dispatches probe2_double; button 0 must not re-dispatch.
   EXPECT_CALL( *pub_probe_press_, publish( Field( &std_msgs::msg::String::data,
                                                   HasSubstr( "press:probe2_double:" ) ) ) )
       .Times( 1 );
@@ -292,10 +280,93 @@ TEST_F( HectorGamepadManagerDoublePressTest, InterleavedDoublePressButtonsTrackI
   sendJoy();
 }
 
-// Test H — Edge case: double_press_window_sec = 0 should disable buffering entirely. Buttons
-// configured with on_double_press still load, but on_press fires on the same frame as the
-// physical press (no waiting), and a second quick press just fires on_press again. on_double_press
-// is effectively unreachable when the window is 0 — but we must not deadlock or stuck-press.
+// Config switch while a double-press button is pressed must synthesize a release.
+TEST_F( HectorGamepadManagerDoublePressTest, ConfigSwitchWhileHeldFlushesRelease )
+{
+  // Drive button 0 into press_dispatched=true via timeout flush while still held.
+  setButton( 0, 1 );
+  sendJoy();
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  advanceMs( 300 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  // Trigger config switch via button 7; the outgoing config's button 0 must receive a synthesized release.
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_hold_, publish( _ ) ).Times( 0 );
+
+  // Release button 0 first so handleConfigurationSwitches doesn't race it.
+  setButton( 0, 0 );
+  setButton( 7, 1 );
+  sendJoy();
+}
+
+// A backward clock jump must not strand a buffered press; negative deltas count as expired.
+TEST_F( HectorGamepadManagerDoublePressTest, BackwardClockJumpDoesNotStickBufferedPress )
+{
+  advanceMs( 10000 );
+
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+  clock_->resetClock( 5000000000L ); // 5.0s, below the 10s anchor
+
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  sendJoy();
+}
+
+// A buffered tap must flush before the next rising edge overwrites last_press_time.
+TEST_F( HectorGamepadManagerDoublePressTest, ExpiredBufferedPressFlushesOnNextRisingEdge )
+{
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+
+  // Wait long past the window without any joy callback.
+  advanceMs( 1000 );
+
+  // Fresh press: the original tap flushes as press+release before the new press buffers.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  setButton( 0, 1 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_release_.get() );
+
+  // Confirm the new press is buffered: until its window expires, no press fires.
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  setButton( 0, 0 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  // Once the new window expires, the second tap also flushes as a single press+release.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  advanceMs( 300 );
+  sendJoy();
+}
+
+// double_press_window_sec = 0 disables buffering entirely; on_double_press becomes unreachable.
 class HectorGamepadManagerZeroWindowTest : public ::testing::Test
 {
 protected:
@@ -355,13 +426,10 @@ protected:
   void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
 };
 
-// With a zero window, a press of a double-press-configured button does not stick: on the same
-// frame the press is registered, the timeout already expired, so the press flushes immediately,
-// and a release on the next frame (after the button goes up) closes the cycle cleanly.
+// A zero-window press flushes immediately and pairs cleanly with a release on button-up.
 TEST_F( HectorGamepadManagerZeroWindowTest, ZeroWindowFlushesPressImmediately )
 {
-  // Press → immediate flush (window already expired). The button is still held, so the timeout
-  // path leaves press_dispatched=true and no release fires yet.
+  // Press flushes immediately; button still held leaves press_dispatched=true.
   EXPECT_CALL( *pub_probe_press_,
                publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
       .Times( 1 );

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -1,0 +1,127 @@
+#include <gmock/gmock.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rtest/publisher_mock.hpp>
+#include <rtest/subscription_mock.hpp>
+
+#include <sensor_msgs/msg/joy.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <hector_gamepad_manager/hector_gamepad_manager.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::Field;
+using ::testing::HasSubstr;
+
+constexpr int MAX_BUTTONS = 25;
+constexpr int MAX_AXES = 8;
+
+// Verifies that malformed YAML entries (missing function: in legacy format, missing on_press
+// in new format) are skipped with a warning instead of throwing or registering broken mappings.
+class HectorGamepadManagerMalformedConfigTest : public ::testing::Test
+{
+protected:
+  rclcpp::NodeOptions opts_;
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<hector_gamepad_manager::HectorGamepadManager> manager_;
+
+  std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Joy>> sub_joy_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_config_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_press_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_hold_;
+  std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_release_;
+
+  sensor_msgs::msg::Joy joy_msg_;
+
+  static std::string paramsFilePath()
+  {
+    auto path = std::filesystem::path( __FILE__ ).parent_path() / "config" /
+                "manager_internal_malformed_params.yaml";
+    return path.string();
+  }
+
+  void SetUp() override
+  {
+    opts_ = rclcpp::NodeOptions();
+    opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
+
+    // Construction must not throw, even though the config has malformed entries.
+    ASSERT_NO_THROW( {
+      node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_malformed_test", opts_ );
+      manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
+    } );
+
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    pub_probe_press_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
+    pub_probe_hold_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/hold" );
+    pub_probe_release_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/release" );
+
+    ASSERT_TRUE( sub_joy_ ) << "Joy subscription should be created even when some button mappings "
+                               "are malformed.";
+    ASSERT_TRUE( pub_config_ );
+    ASSERT_TRUE( pub_probe_press_ );
+
+    EXPECT_CALL( *pub_config_, publish( _ ) ).Times( AnyNumber() );
+
+    resetJoy();
+  }
+
+  void resetJoy()
+  {
+    joy_msg_.axes = std::vector<float>( MAX_AXES, 0.0f );
+    joy_msg_.buttons = std::vector<int>( MAX_BUTTONS, 0 );
+    joy_msg_.axes[2] = 1.0f;
+    joy_msg_.axes[5] = 1.0f;
+  }
+
+  void setButton( int id, int value ) { joy_msg_.buttons[id] = value; }
+
+  void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
+};
+
+// Test E — Pressing the buttons whose mappings were malformed must not dispatch anything (the
+// mappings should have been skipped at load time, not registered with empty function names).
+TEST_F( HectorGamepadManagerMalformedConfigTest, MalformedMappingsAreSkipped )
+{
+  EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_hold_, publish( _ ) ).Times( 0 );
+  EXPECT_CALL( *pub_probe_release_, publish( _ ) ).Times( 0 );
+
+  // Button 0: legacy format with plugin: but no function: — must be skipped.
+  setButton( 0, 1 );
+  sendJoy();
+  setButton( 0, 0 );
+  sendJoy();
+
+  // Button 1: new format with no on_press — must be skipped.
+  setButton( 1, 1 );
+  sendJoy();
+  setButton( 1, 0 );
+  sendJoy();
+}
+
+// Test F — A valid entry coexisting with malformed entries in the same config still works.
+TEST_F( HectorGamepadManagerMalformedConfigTest, ValidMappingsStillWorkAlongsideMalformedOnes )
+{
+  EXPECT_CALL( *pub_probe_press_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "press:probe:" ) ) ) )
+      .Times( 1 );
+  setButton( 2, 1 );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  EXPECT_CALL( *pub_probe_release_,
+               publish( Field( &std_msgs::msg::String::data, HasSubstr( "release:probe:" ) ) ) )
+      .Times( 1 );
+  setButton( 2, 0 );
+  sendJoy();
+}

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -102,10 +102,17 @@ TEST_F( HectorGamepadManagerMalformedConfigTest, MalformedMappingsAreSkipped )
   setButton( 0, 0 );
   sendJoy();
 
-  // Button 1: new format with no on_press — must be skipped.
+  // Button 1: new format with on_hold/on_release but no on_press — must be skipped.
   setButton( 1, 1 );
   sendJoy();
   setButton( 1, 0 );
+  sendJoy();
+
+  // Button 3: new format with on_double_press but no on_press — must be skipped. Without
+  // the strict check, the timeout-flush path would dispatch handlePress("") on this single tap.
+  setButton( 3, 1 );
+  sendJoy();
+  setButton( 3, 0 );
   sendJoy();
 }
 

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -21,8 +21,7 @@ using ::testing::HasSubstr;
 constexpr int MAX_BUTTONS = 25;
 constexpr int MAX_AXES = 8;
 
-// Verifies that malformed YAML entries (missing function: in legacy format, missing on_press
-// in new format) are skipped with a warning instead of throwing or registering broken mappings.
+// Verifies malformed YAML entries are skipped with a warning rather than throwing or registering broken mappings.
 class HectorGamepadManagerMalformedConfigTest : public ::testing::Test
 {
 protected:
@@ -69,6 +68,8 @@ protected:
                                "are malformed.";
     ASSERT_TRUE( pub_config_ );
     ASSERT_TRUE( pub_probe_press_ );
+    ASSERT_TRUE( pub_probe_hold_ );
+    ASSERT_TRUE( pub_probe_release_ );
 
     EXPECT_CALL( *pub_config_, publish( _ ) ).Times( AnyNumber() );
 
@@ -88,8 +89,7 @@ protected:
   void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
 };
 
-// Test E — Pressing the buttons whose mappings were malformed must not dispatch anything (the
-// mappings should have been skipped at load time, not registered with empty function names).
+// Pressing buttons with malformed mappings must not dispatch anything.
 TEST_F( HectorGamepadManagerMalformedConfigTest, MalformedMappingsAreSkipped )
 {
   EXPECT_CALL( *pub_probe_press_, publish( _ ) ).Times( 0 );
@@ -108,8 +108,7 @@ TEST_F( HectorGamepadManagerMalformedConfigTest, MalformedMappingsAreSkipped )
   setButton( 1, 0 );
   sendJoy();
 
-  // Button 3: new format with on_double_press but no on_press — must be skipped. Without
-  // the strict check, the timeout-flush path would dispatch handlePress("") on this single tap.
+  // Button 3: new format with on_double_press but no on_press — must be skipped.
   setButton( 3, 1 );
   sendJoy();
   setButton( 3, 0 );

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -17,6 +17,7 @@ set(DEPENDENCIES
     controller_orchestrator
     geometry_msgs
     hector_gamepad_plugin_interface
+    hector_ros_controllers_msgs
     hector_ros2_utils
     moveit_msgs
     pluginlib

--- a/hector_gamepad_manager_plugins/CMakeLists.txt
+++ b/hector_gamepad_manager_plugins/CMakeLists.txt
@@ -86,6 +86,26 @@ if(BUILD_TESTING)
                ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
 
+  # Standalone test for FlipperPlugin's action-client paths. We can't fold the
+  # action_client_mock into ${PROJECT_NAME}_test_doubles because
+  # BatteryMonitorPlugin transitively pulls ros_babel_fish, which specializes
+  # rclcpp_action::Client and is incompatible with the mocked Client class. So
+  # we link a flipper-only object set against the mock here.
+  ament_add_gmock(test_flipper_plugin test/test_flipper_plugin.cpp
+                  src/flipper_plugin.cpp)
+  target_include_directories(
+    test_flipper_plugin
+    PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+  ament_target_dependencies(test_flipper_plugin ${DEPENDENCIES} rtest)
+  target_link_libraries(
+    test_flipper_plugin
+    rtest::publisher_mock
+    rtest::subscription_mock
+    rtest::service_mock
+    rtest::service_client_mock
+    rtest::action_client_mock
+    rtest::rtest_common)
+
   file(MAKE_DIRECTORY
        "${CMAKE_CURRENT_BINARY_DIR}/share/hector_gamepad_manager_plugins")
   file(MAKE_DIRECTORY

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -80,6 +80,10 @@ private:
 
   rclcpp_action::Client<DriveFlipperGroupAction>::SharedPtr drive_flipper_client_;
   rclcpp_action::Client<SyncFlipperGroupAction>::SharedPtr sync_flipper_client_;
+
+  // Non-null while a goal is accepted and pending; duplicate requests are dropped.
+  rclcpp_action::ClientGoalHandle<DriveFlipperGroupAction>::SharedPtr drive_in_flight_;
+  rclcpp_action::ClientGoalHandle<SyncFlipperGroupAction>::SharedPtr sync_in_flight_;
 };
 } // namespace hector_gamepad_manager_plugins
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/flipper_plugin.hpp
@@ -3,8 +3,12 @@
 
 #include <hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp>
 
+#include "rclcpp_action/rclcpp_action.hpp"
 #include "std_msgs/msg/float64_multi_array.hpp"
 #include <hector_ros2_utils/parameters/reconfigurable_parameter.hpp>
+
+#include <hector_ros_controllers_msgs/action/drive_flipper_group.hpp>
+#include <hector_ros_controllers_msgs/action/sync_flipper_group.hpp>
 
 namespace hector_gamepad_manager_plugins
 {
@@ -61,11 +65,21 @@ private:
   void handleIndividualFlipperControlInput( const double base_speed_factor, const bool is_button,
                                             const std::string &function );
 
+  void handleFlipperUpright( const std::string &function );
+  void handleFlipperSync( const std::string &function );
+
   void resetCommands();
 
   void publishCommands() const;
 
   bool checkCurrentCmdIsZero() const;
+
+  // Action clients for flipper group actions
+  using DriveFlipperGroupAction = hector_ros_controllers_msgs::action::DriveFlipperGroup;
+  using SyncFlipperGroupAction = hector_ros_controllers_msgs::action::SyncFlipperGroup;
+
+  rclcpp_action::Client<DriveFlipperGroupAction>::SharedPtr drive_flipper_client_;
+  rclcpp_action::Client<SyncFlipperGroupAction>::SharedPtr sync_flipper_client_;
 };
 } // namespace hector_gamepad_manager_plugins
 

--- a/hector_gamepad_manager_plugins/package.xml
+++ b/hector_gamepad_manager_plugins/package.xml
@@ -17,6 +17,7 @@
   <depend>geometry_msgs</depend>
   <depend>hector_gamepad_plugin_interface</depend>
   <depend>hector_ros2_utils</depend>
+  <depend>hector_ros_controllers_msgs</depend>
   <depend>moveit_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rcl_interfaces</depend>

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -267,6 +267,13 @@ void FlipperPlugin::handleFlipperUpright( const std::string &function )
     return;
   }
 
+  if ( drive_in_flight_ ) {
+    RCLCPP_WARN( node_->get_logger(),
+                 "Drive flipper goal already in flight; dropping new request for %s",
+                 function.c_str() );
+    return;
+  }
+
   auto goal = DriveFlipperGroupAction::Goal();
   // target_position = 0 means use the upright_position parameter on the controller side
   goal.target_position = 0.0;
@@ -285,9 +292,15 @@ void FlipperPlugin::handleFlipperUpright( const std::string &function )
   RCLCPP_INFO( node_->get_logger(), "Driving %s to upright position", goal.group_name.c_str() );
 
   auto send_goal_options = rclcpp_action::Client<DriveFlipperGroupAction>::SendGoalOptions();
+  send_goal_options.goal_response_callback =
+      [this]( const rclcpp_action::ClientGoalHandle<DriveFlipperGroupAction>::SharedPtr &handle ) {
+        if ( handle )
+          drive_in_flight_ = handle;
+      };
   send_goal_options.result_callback =
       [this, group = goal.group_name](
           const rclcpp_action::ClientGoalHandle<DriveFlipperGroupAction>::WrappedResult &result ) {
+        drive_in_flight_.reset();
         const char *msg = result.result ? result.result->message.c_str() : "(no result payload)";
         if ( result.code == rclcpp_action::ResultCode::SUCCEEDED ) {
           RCLCPP_INFO( node_->get_logger(), "Drive %s upright: %s", group.c_str(), msg );
@@ -309,6 +322,13 @@ void FlipperPlugin::handleFlipperSync( const std::string &function )
     return;
   }
 
+  if ( sync_in_flight_ ) {
+    RCLCPP_WARN( node_->get_logger(),
+                 "Sync flipper goal already in flight; dropping new request for %s",
+                 function.c_str() );
+    return;
+  }
+
   auto goal = SyncFlipperGroupAction::Goal();
   goal.max_velocity = 0.0;     // use controller default
   goal.max_acceleration = 0.0; // use controller default
@@ -327,8 +347,14 @@ void FlipperPlugin::handleFlipperSync( const std::string &function )
   RCLCPP_INFO( node_->get_logger(), "Syncing flippers: %s", function.c_str() );
 
   auto send_goal_options = rclcpp_action::Client<SyncFlipperGroupAction>::SendGoalOptions();
+  send_goal_options.goal_response_callback =
+      [this]( const rclcpp_action::ClientGoalHandle<SyncFlipperGroupAction>::SharedPtr &handle ) {
+        if ( handle )
+          sync_in_flight_ = handle;
+      };
   send_goal_options.result_callback =
       [this]( const rclcpp_action::ClientGoalHandle<SyncFlipperGroupAction>::WrappedResult &result ) {
+        sync_in_flight_.reset();
         const char *msg = result.result ? result.result->message.c_str() : "(no result payload)";
         if ( result.code == rclcpp_action::ResultCode::SUCCEEDED ) {
           RCLCPP_INFO( node_->get_logger(), "Flipper sync: %s", msg );

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -52,12 +52,12 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
 
   // Action clients for flipper group actions
   const std::string robot_ns = node_->get_parameter( "robot_namespace" ).as_string();
-  node_->declare_parameter<std::string>( plugin_namespace + ".drive_flipper_action",
-                                         "/" + robot_ns +
-                                             "/vel_to_pos_controller/drive_flipper_group" );
-  node_->declare_parameter<std::string>( plugin_namespace + ".sync_flipper_action",
-                                         "/" + robot_ns +
-                                             "/vel_to_pos_controller/sync_flipper_group" );
+  node_->declare_parameter<std::string>(
+      plugin_namespace + ".drive_flipper_action",
+      "/" + robot_ns + "/flipper_velocity_to_position_controller/drive_flipper_group" );
+  node_->declare_parameter<std::string>(
+      plugin_namespace + ".sync_flipper_action",
+      "/" + robot_ns + "/flipper_velocity_to_position_controller/sync_flipper_group" );
 
   drive_flipper_client_ = rclcpp_action::create_client<DriveFlipperGroupAction>(
       node_, node_->get_parameter( plugin_namespace + ".drive_flipper_action" ).as_string() );

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -288,12 +288,11 @@ void FlipperPlugin::handleFlipperUpright( const std::string &function )
   send_goal_options.result_callback =
       [this, group = goal.group_name](
           const rclcpp_action::ClientGoalHandle<DriveFlipperGroupAction>::WrappedResult &result ) {
+        const char *msg = result.result ? result.result->message.c_str() : "(no result payload)";
         if ( result.code == rclcpp_action::ResultCode::SUCCEEDED ) {
-          RCLCPP_INFO( node_->get_logger(), "Drive %s upright: %s", group.c_str(),
-                       result.result->message.c_str() );
+          RCLCPP_INFO( node_->get_logger(), "Drive %s upright: %s", group.c_str(), msg );
         } else {
-          RCLCPP_WARN( node_->get_logger(), "Drive %s upright failed: %s", group.c_str(),
-                       result.result->message.c_str() );
+          RCLCPP_WARN( node_->get_logger(), "Drive %s upright failed: %s", group.c_str(), msg );
         }
       };
 
@@ -330,11 +329,11 @@ void FlipperPlugin::handleFlipperSync( const std::string &function )
   auto send_goal_options = rclcpp_action::Client<SyncFlipperGroupAction>::SendGoalOptions();
   send_goal_options.result_callback =
       [this]( const rclcpp_action::ClientGoalHandle<SyncFlipperGroupAction>::WrappedResult &result ) {
+        const char *msg = result.result ? result.result->message.c_str() : "(no result payload)";
         if ( result.code == rclcpp_action::ResultCode::SUCCEEDED ) {
-          RCLCPP_INFO( node_->get_logger(), "Flipper sync: %s", result.result->message.c_str() );
+          RCLCPP_INFO( node_->get_logger(), "Flipper sync: %s", msg );
         } else {
-          RCLCPP_WARN( node_->get_logger(), "Flipper sync failed: %s",
-                       result.result->message.c_str() );
+          RCLCPP_WARN( node_->get_logger(), "Flipper sync failed: %s", msg );
         }
       };
 

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -50,6 +50,20 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
       "/" + node_->get_parameter( "robot_namespace" ).as_string() + "/" + command_topic, 10 );
 
+  // Action clients for flipper group actions
+  const std::string robot_ns = node_->get_parameter( "robot_namespace" ).as_string();
+  node_->declare_parameter<std::string>( plugin_namespace + ".drive_flipper_action",
+                                         "/" + robot_ns +
+                                             "/vel_to_pos_controller/drive_flipper_group" );
+  node_->declare_parameter<std::string>( plugin_namespace + ".sync_flipper_action",
+                                         "/" + robot_ns +
+                                             "/vel_to_pos_controller/sync_flipper_group" );
+
+  drive_flipper_client_ = rclcpp_action::create_client<DriveFlipperGroupAction>(
+      node_, node_->get_parameter( plugin_namespace + ".drive_flipper_action" ).as_string() );
+  sync_flipper_client_ = rclcpp_action::create_client<SyncFlipperGroupAction>(
+      node_, node_->get_parameter( plugin_namespace + ".sync_flipper_action" ).as_string() );
+
   active_ = true;
 }
 
@@ -63,6 +77,19 @@ void FlipperPlugin::handlePress( const std::string &function, const std::string 
 
   if ( function == "individual_back_flipper_control_mode" ) {
     individual_back_flipper_mode_ = !individual_front_flipper_mode_;
+    return;
+  }
+
+  // Move flipper pair to upright position (triggered by double-press)
+  if ( function == "flipper_front_upright" || function == "flipper_back_upright" ) {
+    handleFlipperUpright( function );
+    return;
+  }
+
+  // Sync flipper pairs (triggered by double-press)
+  if ( function == "sync_front_flippers" || function == "sync_back_flippers" ||
+       function == "sync_all_flippers" ) {
+    handleFlipperSync( function );
     return;
   }
 
@@ -228,6 +255,90 @@ void FlipperPlugin::handleIndividualFlipperControlInput( const double base_speed
         axis_vel_commands_[2] = vel * flipper_back_factor_;
     }
   }
+}
+
+void FlipperPlugin::handleFlipperUpright( const std::string &function )
+{
+  if ( !active_ )
+    return;
+
+  if ( !drive_flipper_client_->action_server_is_ready() ) {
+    RCLCPP_WARN( node_->get_logger(), "Drive flipper action server not available" );
+    return;
+  }
+
+  auto goal = DriveFlipperGroupAction::Goal();
+  // target_position = 0 means use the upright_position parameter on the controller side
+  goal.target_position = 0.0;
+  goal.max_velocity = 0.0;     // use controller default
+  goal.max_acceleration = 0.0; // use controller default
+
+  if ( function == "flipper_front_upright" ) {
+    goal.group_name = "flipper_front";
+  } else if ( function == "flipper_back_upright" ) {
+    goal.group_name = "flipper_back";
+  } else {
+    RCLCPP_WARN( node_->get_logger(), "Unknown flipper upright function: %s", function.c_str() );
+    return;
+  }
+
+  RCLCPP_INFO( node_->get_logger(), "Driving %s to upright position", goal.group_name.c_str() );
+
+  auto send_goal_options = rclcpp_action::Client<DriveFlipperGroupAction>::SendGoalOptions();
+  send_goal_options.result_callback =
+      [this, group = goal.group_name](
+          const rclcpp_action::ClientGoalHandle<DriveFlipperGroupAction>::WrappedResult &result ) {
+        if ( result.code == rclcpp_action::ResultCode::SUCCEEDED ) {
+          RCLCPP_INFO( node_->get_logger(), "Drive %s upright: %s", group.c_str(),
+                       result.result->message.c_str() );
+        } else {
+          RCLCPP_WARN( node_->get_logger(), "Drive %s upright failed: %s", group.c_str(),
+                       result.result->message.c_str() );
+        }
+      };
+
+  drive_flipper_client_->async_send_goal( goal, send_goal_options );
+}
+
+void FlipperPlugin::handleFlipperSync( const std::string &function )
+{
+  if ( !active_ )
+    return;
+
+  if ( !sync_flipper_client_->action_server_is_ready() ) {
+    RCLCPP_WARN( node_->get_logger(), "Sync flipper action server not available" );
+    return;
+  }
+
+  auto goal = SyncFlipperGroupAction::Goal();
+  goal.max_velocity = 0.0;     // use controller default
+  goal.max_acceleration = 0.0; // use controller default
+
+  if ( function == "sync_front_flippers" ) {
+    goal.group_names = { "flipper_front" };
+  } else if ( function == "sync_back_flippers" ) {
+    goal.group_names = { "flipper_back" };
+  } else if ( function == "sync_all_flippers" ) {
+    goal.group_names = {}; // empty = sync all groups
+  } else {
+    RCLCPP_WARN( node_->get_logger(), "Unknown flipper sync function: %s", function.c_str() );
+    return;
+  }
+
+  RCLCPP_INFO( node_->get_logger(), "Syncing flippers: %s", function.c_str() );
+
+  auto send_goal_options = rclcpp_action::Client<SyncFlipperGroupAction>::SendGoalOptions();
+  send_goal_options.result_callback =
+      [this]( const rclcpp_action::ClientGoalHandle<SyncFlipperGroupAction>::WrappedResult &result ) {
+        if ( result.code == rclcpp_action::ResultCode::SUCCEEDED ) {
+          RCLCPP_INFO( node_->get_logger(), "Flipper sync: %s", result.result->message.c_str() );
+        } else {
+          RCLCPP_WARN( node_->get_logger(), "Flipper sync failed: %s",
+                       result.result->message.c_str() );
+        }
+      };
+
+  sync_flipper_client_->async_send_goal( goal, send_goal_options );
 }
 
 void FlipperPlugin::resetCommands()

--- a/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
@@ -1,0 +1,181 @@
+#include <gmock/gmock.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rtest/action_client_mock.hpp>
+
+#include <hector_gamepad_manager_plugins/flipper_plugin.hpp>
+#include <hector_gamepad_plugin_interface/blackboard.hpp>
+#include <hector_gamepad_plugin_interface/feedback_manager.hpp>
+
+#include <hector_ros_controllers_msgs/action/drive_flipper_group.hpp>
+#include <hector_ros_controllers_msgs/action/sync_flipper_group.hpp>
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SaveArg;
+
+using DriveAction = hector_ros_controllers_msgs::action::DriveFlipperGroup;
+using SyncAction = hector_ros_controllers_msgs::action::SyncFlipperGroup;
+
+// Direct unit tests for FlipperPlugin's action-client paths. The plugin is exercised
+// without going through pluginlib so we can attach rtest's action_client_mock without
+// dragging in BatteryMonitorPlugin's babel_fish dependency, which is incompatible
+// with the mocked rclcpp_action::Client class.
+class FlipperPluginTest : public ::testing::Test
+{
+protected:
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<hector_gamepad_manager_plugins::FlipperPlugin> plugin_;
+  std::shared_ptr<rtest::experimental::ActionClientMock<DriveAction>> drive_mock_;
+  std::shared_ptr<rtest::experimental::ActionClientMock<SyncAction>> sync_mock_;
+
+  void SetUp() override
+  {
+    node_ = std::make_shared<rclcpp::Node>( "flipper_plugin_test" );
+    node_->declare_parameter<std::string>( "robot_namespace", "athena" );
+
+    plugin_ = std::make_shared<hector_gamepad_manager_plugins::FlipperPlugin>();
+    plugin_->initializePlugin( node_, node_, "hector_gamepad_manager_plugins::FlipperPlugin",
+                               std::make_shared<hector_gamepad_plugin_interface::Blackboard>(),
+                               std::make_shared<hector_gamepad_plugin_interface::FeedbackManager>(),
+                               nullptr );
+
+    drive_mock_ = rtest::experimental::findActionClient<DriveAction>(
+        node_, "/athena/vel_to_pos_controller/drive_flipper_group" );
+    sync_mock_ = rtest::experimental::findActionClient<SyncAction>(
+        node_, "/athena/vel_to_pos_controller/sync_flipper_group" );
+
+    ASSERT_TRUE( drive_mock_ );
+    ASSERT_TRUE( sync_mock_ );
+  }
+};
+
+// flipper_front_upright sends a goal with group_name="flipper_front" when the action
+// server is ready. target_position 0 lets the controller pick its configured upright pose.
+TEST_F( FlipperPluginTest, FrontUprightSendsGoalWithFrontGroup )
+{
+  EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  DriveAction::Goal sent_goal{};
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<0>( &sent_goal ),
+                        rtest::experimental::ReturnGoalHandleFuture(
+                            rclcpp_action::ClientGoalHandle<DriveAction>::SharedPtr{} ) ) );
+
+  plugin_->handlePress( "flipper_front_upright", "test_id" );
+
+  EXPECT_EQ( sent_goal.group_name, "flipper_front" );
+  EXPECT_EQ( sent_goal.target_position, 0.0 );
+}
+
+// flipper_back_upright routes to group_name="flipper_back" on the same client.
+TEST_F( FlipperPluginTest, BackUprightSendsGoalWithBackGroup )
+{
+  EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  DriveAction::Goal sent_goal{};
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<0>( &sent_goal ),
+                        rtest::experimental::ReturnGoalHandleFuture(
+                            rclcpp_action::ClientGoalHandle<DriveAction>::SharedPtr{} ) ) );
+
+  plugin_->handlePress( "flipper_back_upright", "test_id" );
+
+  EXPECT_EQ( sent_goal.group_name, "flipper_back" );
+}
+
+// When the action server isn't ready, no goal is sent — the plugin only logs a warning.
+TEST_F( FlipperPluginTest, UprightSkippedWhenServerNotReady )
+{
+  EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( false ) );
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) ).Times( 0 );
+
+  plugin_->handlePress( "flipper_front_upright", "test_id" );
+}
+
+// sync_front_flippers sends a SyncFlipperGroup goal with group_names=["flipper_front"].
+TEST_F( FlipperPluginTest, SyncFrontSendsGoalWithFrontGroup )
+{
+  EXPECT_CALL( *sync_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  SyncAction::Goal sent_goal{};
+  EXPECT_CALL( *sync_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<0>( &sent_goal ),
+                        rtest::experimental::ReturnGoalHandleFuture(
+                            rclcpp_action::ClientGoalHandle<SyncAction>::SharedPtr{} ) ) );
+
+  plugin_->handlePress( "sync_front_flippers", "test_id" );
+
+  ASSERT_EQ( sent_goal.group_names.size(), 1u );
+  EXPECT_EQ( sent_goal.group_names[0], "flipper_front" );
+}
+
+// sync_all_flippers sends an empty group_names list, which the controller interprets as
+// "every group I know about". Verifying the empty list is the contract.
+TEST_F( FlipperPluginTest, SyncAllSendsGoalWithEmptyGroupList )
+{
+  EXPECT_CALL( *sync_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  SyncAction::Goal sent_goal{};
+  EXPECT_CALL( *sync_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<0>( &sent_goal ),
+                        rtest::experimental::ReturnGoalHandleFuture(
+                            rclcpp_action::ClientGoalHandle<SyncAction>::SharedPtr{} ) ) );
+
+  plugin_->handlePress( "sync_all_flippers", "test_id" );
+
+  EXPECT_TRUE( sent_goal.group_names.empty() );
+}
+
+// Regression test for the null-result-payload defensive check. A SUCCEEDED result with a
+// null result pointer must not crash the result callback. This used to dereference
+// result.result->message unconditionally.
+TEST_F( FlipperPluginTest, UprightResultCallbackHandlesNullResultPayload )
+{
+  EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  rclcpp_action::Client<DriveAction>::SendGoalOptions captured_opts;
+  auto goal_handle = drive_mock_->makeClientGoalHandle();
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<1>( &captured_opts ),
+                        rtest::experimental::ReturnGoalHandleFuture( goal_handle ) ) );
+
+  plugin_->handlePress( "flipper_front_upright", "test_id" );
+
+  ASSERT_NE( captured_opts.result_callback, nullptr );
+
+  rclcpp_action::ClientGoalHandle<DriveAction>::WrappedResult result;
+  result.code = rclcpp_action::ResultCode::SUCCEEDED;
+  result.result = nullptr; // the case the recent fix guards against
+  EXPECT_NO_THROW( captured_opts.result_callback( result ) );
+}
+
+// Same regression check for the sync action's result callback.
+TEST_F( FlipperPluginTest, SyncResultCallbackHandlesNullResultPayload )
+{
+  EXPECT_CALL( *sync_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  rclcpp_action::Client<SyncAction>::SendGoalOptions captured_opts;
+  auto goal_handle = sync_mock_->makeClientGoalHandle();
+  EXPECT_CALL( *sync_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<1>( &captured_opts ),
+                        rtest::experimental::ReturnGoalHandleFuture( goal_handle ) ) );
+
+  plugin_->handlePress( "sync_back_flippers", "test_id" );
+
+  ASSERT_NE( captured_opts.result_callback, nullptr );
+
+  rclcpp_action::ClientGoalHandle<SyncAction>::WrappedResult result;
+  result.code = rclcpp_action::ResultCode::ABORTED;
+  result.result = nullptr;
+  EXPECT_NO_THROW( captured_opts.result_callback( result ) );
+}
+
+int main( int argc, char **argv )
+{
+  ::testing::InitGoogleMock( &argc, argv );
+  rclcpp::init( argc, argv );
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
@@ -38,9 +38,9 @@ protected:
                                nullptr );
 
     drive_mock_ = rtest::experimental::findActionClient<DriveAction>(
-        node_, "/athena/vel_to_pos_controller/drive_flipper_group" );
+        node_, "/athena/flipper_velocity_to_position_controller/drive_flipper_group" );
     sync_mock_ = rtest::experimental::findActionClient<SyncAction>(
-        node_, "/athena/vel_to_pos_controller/sync_flipper_group" );
+        node_, "/athena/flipper_velocity_to_position_controller/sync_flipper_group" );
 
     ASSERT_TRUE( drive_mock_ );
     ASSERT_TRUE( sync_mock_ );

--- a/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
@@ -17,10 +17,7 @@ using ::testing::SaveArg;
 using DriveAction = hector_ros_controllers_msgs::action::DriveFlipperGroup;
 using SyncAction = hector_ros_controllers_msgs::action::SyncFlipperGroup;
 
-// Direct unit tests for FlipperPlugin's action-client paths. The plugin is exercised
-// without going through pluginlib so we can attach rtest's action_client_mock without
-// dragging in BatteryMonitorPlugin's babel_fish dependency, which is incompatible
-// with the mocked rclcpp_action::Client class.
+// Direct unit tests for FlipperPlugin's action-client paths; bypasses pluginlib to attach action_client_mock without pulling in BatteryMonitorPlugin's babel_fish dependency.
 class FlipperPluginTest : public ::testing::Test
 {
 protected:
@@ -50,8 +47,7 @@ protected:
   }
 };
 
-// flipper_front_upright sends a goal with group_name="flipper_front" when the action
-// server is ready. target_position 0 lets the controller pick its configured upright pose.
+// flipper_front_upright sends a goal with group_name="flipper_front" and target_position 0.
 TEST_F( FlipperPluginTest, FrontUprightSendsGoalWithFrontGroup )
 {
   EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
@@ -110,8 +106,7 @@ TEST_F( FlipperPluginTest, SyncFrontSendsGoalWithFrontGroup )
   EXPECT_EQ( sent_goal.group_names[0], "flipper_front" );
 }
 
-// sync_all_flippers sends an empty group_names list, which the controller interprets as
-// "every group I know about". Verifying the empty list is the contract.
+// sync_all_flippers sends an empty group_names list — the contract for "all groups".
 TEST_F( FlipperPluginTest, SyncAllSendsGoalWithEmptyGroupList )
 {
   EXPECT_CALL( *sync_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
@@ -127,9 +122,7 @@ TEST_F( FlipperPluginTest, SyncAllSendsGoalWithEmptyGroupList )
   EXPECT_TRUE( sent_goal.group_names.empty() );
 }
 
-// Regression test for the null-result-payload defensive check. A SUCCEEDED result with a
-// null result pointer must not crash the result callback. This used to dereference
-// result.result->message unconditionally.
+// Regression: a SUCCEEDED result with a null result pointer must not crash the callback.
 TEST_F( FlipperPluginTest, UprightResultCallbackHandlesNullResultPayload )
 {
   EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
@@ -169,6 +162,36 @@ TEST_F( FlipperPluginTest, SyncResultCallbackHandlesNullResultPayload )
   result.code = rclcpp_action::ResultCode::ABORTED;
   result.result = nullptr;
   EXPECT_NO_THROW( captured_opts.result_callback( result ) );
+}
+
+// A second upright press while a goal is in flight must be dropped; clears after result.
+TEST_F( FlipperPluginTest, UprightDropsRequestWhileGoalInFlight )
+{
+  EXPECT_CALL( *drive_mock_, action_server_is_ready() ).WillRepeatedly( Return( true ) );
+
+  rclcpp_action::Client<DriveAction>::SendGoalOptions captured_opts;
+  auto goal_handle = drive_mock_->makeClientGoalHandle();
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) )
+      .WillOnce( DoAll( SaveArg<1>( &captured_opts ),
+                        rtest::experimental::ReturnGoalHandleFuture( goal_handle ) ) );
+
+  plugin_->handlePress( "flipper_front_upright", "test_id" );
+  ASSERT_NE( captured_opts.goal_response_callback, nullptr );
+  captured_opts.goal_response_callback( goal_handle );
+
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) ).Times( 0 );
+  plugin_->handlePress( "flipper_front_upright", "test_id" );
+
+  ASSERT_NE( captured_opts.result_callback, nullptr );
+  rclcpp_action::ClientGoalHandle<DriveAction>::WrappedResult result;
+  result.code = rclcpp_action::ResultCode::SUCCEEDED;
+  result.result = nullptr;
+  captured_opts.result_callback( result );
+
+  EXPECT_CALL( *drive_mock_, async_send_goal( _, _ ) )
+      .WillOnce( rtest::experimental::ReturnGoalHandleFuture(
+          rclcpp_action::ClientGoalHandle<DriveAction>::SharedPtr{} ) );
+  plugin_->handlePress( "flipper_front_upright", "test_id" );
 }
 
 int main( int argc, char **argv )


### PR DESCRIPTION
## Summary

Adds **double-press button support** to the gamepad manager and uses it in `FlipperPlugin` to expose two new controller-side actions (drive-to-upright, sync flipper pair) on the existing flipper face buttons. Default driving config is rewired to take advantage of both.

## Per-event button mapping

The button YAML format is extended with `on_press` / `on_double_press` / `on_hold` / `on_release`:

```yaml
buttons:
  4: # Button LB
    plugin: hector_gamepad_manager_plugins::FlipperPlugin
    on_press:
      function: flipper_back_up
    on_double_press:
      function: flipper_back_upright
```

- The basic `plugin: + function:` form still works unchanged.
- Buttons **without** `on_double_press` keep zero-latency dispatch.
- Buttons **with** `on_double_press` buffer the first press for `double_press_window_sec` (new ROS parameter, default **0.25s**) so a second press within the window can be promoted to a double-press.
- `on_hold` and `on_release` default to the `on_press` function if omitted.
- Args go at the button top level (`args:`) and are shared across all events. Per-event `args:` blocks are warned and ignored — the plugin read API doesn't currently distinguish events.

## FlipperPlugin: drive-to-upright and sync actions

New action clients on the `vel_to_pos_controller`:

| Function | Action | Default trigger |
|---|---|---|
| `flipper_front_upright` / `flipper_back_upright` | `DriveFlipperGroup` | double-press RB / LB |
| `sync_front_flippers` / `sync_back_flippers` | `SyncFlipperGroup` | double-press B / X |
| `sync_all_flippers` | `SyncFlipperGroup` (all groups) | not mapped by default |

Action topics are reconfigurable via the `drive_flipper_action` and `sync_flipper_action` plugin parameters. Manual velocity input on an affected flipper group **preempts the running action controller-side** — the plugin fires goals fire-and-forget.

## Default `driving.yaml` changes

| Button | Single press | Double press |
|---|---|---|
| LB | `flipper_back_up` (vel) | `flipper_back_upright` |
| RB | `flipper_front_up` (vel) | `flipper_front_upright` |
| B  | `individual_front_flipper_control_mode` | `sync_front_flippers` |
| X  | `individual_back_flipper_control_mode` | `sync_back_flippers` |
| A / Y | swapped: A = `slow`, Y = `fast` | — |
