### PR TITLE
manipulation_plugin: target standalone gripper controller

### DIFF
--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -22,6 +22,7 @@
       max_drive_linear_speed: 0.5
       max_drive_angular_speed: 0.5
       twist_controller_name: moveit_twist_controller
+      gripper_controller_name: gripper_position_controller
     moveit_plugin:
       start_controllers: [arm_trajectory_controller, gripper_trajectory_controller, flipper_trajectory_controller]
       max_velocity_scaling_factor: 0.1

--- a/hector_gamepad_manager/test/README.md
+++ b/hector_gamepad_manager/test/README.md
@@ -43,7 +43,7 @@ Then the test uses rtest to get:
 - `/ocs/joy` subscription to inject joystick input
 - `/ocs/active_config` publisher to assert config switching
 - `/athena/cmd_vel`, `/athena/moveit_twist_controller/eef_cmd`,
-  `/athena/moveit_twist_controller/gripper_vel_cmd`, and
+  `/athena/gripper_position_controller/velocity_command`, and
   `/athena/flipper_velocity_controller/commands` publishers to assert output
   topics from plugins.
 

--- a/hector_gamepad_manager/test/README.md
+++ b/hector_gamepad_manager/test/README.md
@@ -41,7 +41,7 @@ The file `test/test_hector_gamepad_manager.cpp` creates a single node:
 
 Then the test uses rtest to get:
 - `/ocs/joy` subscription to inject joystick input
-- `/ocs/active_config` publisher to assert config switching
+- `/ocs/joy_teleop_profile` publisher to assert config switching
 - `/athena/cmd_vel`, `/athena/moveit_twist_controller/eef_cmd`,
   `/athena/gripper_position_controller/velocity_command`, and
   `/athena/flipper_velocity_controller/commands` publishers to assert output
@@ -80,11 +80,11 @@ Why this is reliable:
 
 Goal:
 Verify the active configuration changes are published on
-`/ocs/active_config` in the expected sequence.
+`/ocs/joy_teleop_profile` in the expected sequence.
 
 Mechanics:
-1) The test fetches the `active_config` publisher mock:
-   - `auto pub_config = rtest::findPublisher<std_msgs::msg::String>(node, "/ocs/active_config");`
+1) The test fetches the `joy_teleop_profile` publisher mock:
+   - `auto pub_config = rtest::findPublisher<std_msgs::msg::String>(node, "/ocs/joy_teleop_profile");`
 2) It also fetches the `/ocs/joy` subscription for input injection.
 3) It sets an ordered sequence of expectations:
    - First a publish with `"manipulation"`, then a publish with `"driving"`.

--- a/hector_gamepad_manager/test/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/test/config/athena_plugin_config.yaml
@@ -26,6 +26,7 @@
       max_drive_linear_speed: 0.5
       max_drive_angular_speed: 0.5
       twist_controller_name: moveit_twist_controller
+      gripper_controller_name: gripper_position_controller
       enable_drive_cmd: false
     moveit_plugin:
       start_controllers: [arm_trajectory_controller, gripper_trajectory_controller, flipper_trajectory_controller]

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -71,7 +71,7 @@ protected:
     pub_twist_eef_ = rtest::findPublisher<geometry_msgs::msg::TwistStamped>(
         node_, "/athena/moveit_twist_controller/eef_cmd" );
     pub_gripper_ = rtest::findPublisher<std_msgs::msg::Float64>(
-        node_, "/athena/moveit_twist_controller/gripper_vel_cmd" );
+        node_, "/athena/gripper_position_controller/velocity_command" );
     pub_flipper_ = rtest::findPublisher<std_msgs::msg::Float64MultiArray>(
         node_, "/athena/flipper_velocity_controller/commands" );
 

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/manipulation_plugin.hpp
@@ -81,6 +81,7 @@ private:
   double close_gripper_ = 0.0;
 
   std::string twist_controller_name_;
+  std::string gripper_controller_name_;
   geometry_msgs::msg::TwistStamped eef_cmd_;
   geometry_msgs::msg::TwistStamped drive_cmd_;
   std_msgs::msg::Float64 gripper_cmd_;

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -73,6 +73,7 @@ void ManipulationPlugin::handlePress( const std::string &function, const std::st
   } else if ( function == "rotate_roll_counter_clockwise" ) {
     rotate_roll_counter_clockwise_ = -1;
   } else if ( function == "gripper_open" ) {
+    // Gripper joint convention: position increases when opening (0 = closed).
     open_gripper_ = 1;
   } else if ( function == "gripper_close" ) {
     close_gripper_ = -1;

--- a/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/manipulation_plugin.cpp
@@ -44,6 +44,10 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node )
                                          "moveit_twist_controller" );
   twist_controller_name_ =
       node_->get_parameter( plugin_namespace + ".twist_controller_name" ).as_string();
+  node_->declare_parameter<std::string>( plugin_namespace + ".gripper_controller_name",
+                                         "gripper_position_controller" );
+  gripper_controller_name_ =
+      node_->get_parameter( plugin_namespace + ".gripper_controller_name" ).as_string();
   node_->declare_parameter<bool>( plugin_namespace + ".enable_drive_cmd", true );
   enable_drive_cmd_ = node_->get_parameter( plugin_namespace + ".enable_drive_cmd" ).as_bool();
 
@@ -54,7 +58,7 @@ void ManipulationPlugin::initialize( const rclcpp::Node::SharedPtr &node )
     drive_cmd_pub_ = node_->create_publisher<geometry_msgs::msg::TwistStamped>( "cmd_vel", 10 );
   }
   gripper_cmd_pub_ = node_->create_publisher<std_msgs::msg::Float64>(
-      twist_controller_name_ + "/gripper_vel_cmd", 10 );
+      gripper_controller_name_ + "/velocity_command", 10 );
   hold_mode_client_ =
       node_->create_client<std_srvs::srv::SetBool>( twist_controller_name_ + "/hold_mode" );
 }
@@ -140,7 +144,7 @@ void ManipulationPlugin::update()
   const bool is_zero_cmd = isZeroCmd();
   // make sure controllers are active
   if ( last_eef_cmd_zero_ && !is_zero_cmd ) {
-    activateControllers( { twist_controller_name_ } );
+    activateControllers( { twist_controller_name_, gripper_controller_name_ } );
   }
   // avoid repeatedly sending zero commands
   if ( !( last_eef_cmd_zero_ && is_zero_cmd ) ) {
@@ -156,7 +160,7 @@ void ManipulationPlugin::update()
 void ManipulationPlugin::activate()
 {
   active_ = true;
-  activateControllers( { twist_controller_name_ } );
+  activateControllers( { twist_controller_name_, gripper_controller_name_ } );
 }
 
 void ManipulationPlugin::deactivate()


### PR DESCRIPTION
## Summary

Repoint `ManipulationPlugin`'s gripper output at the standalone `GripperPositionEffortController`. The gripper velocity input previously hosted by `moveit_twist_controller` (`~/gripper_vel_cmd`) was removed when the standalone controller was introduced, so the plugin had been publishing to a dead topic. This PR wires it to the new controller's `~/velocity_command` (same `std_msgs/Float64` shape) via a new parameter and ensures the gripper controller is activated alongside the twist controller.

## Changes

- **New parameter** `manipulation_plugin.gripper_controller_name` (default `gripper_position_controller`). `twist_controller_name` is unchanged — eef twist + `hold_mode` service still target `moveit_twist_controller`.
- **Gripper publisher** now points at `<gripper_controller_name>/velocity_command` instead of `<twist_controller_name>/gripper_vel_cmd`.
- **`activateControllers(...)`** in `update()` and `activate()` now activates both the twist and the gripper controller in a single call, so the gripper controller is running before the plugin publishes commands.
- **Test fixture** (`test_hector_gamepad_manager.cpp`) updated to look up the new topic.
- **Plugin configs** (`config/athena_plugin_config.yaml`, `test/config/athena_plugin_config.yaml`) set `gripper_controller_name: gripper_position_controller` explicitly so the wiring is visible at the integration site.
- **`test/README.md`** topic list updated.

Depends on:
- https://github.com/tu-darmstadt-ros-pkg/hector_ros_controllers/pull/30
- https://github.com/tu-darmstadt-ros-pkg/moveit_twist_controller/pull/12