### PR TITLE
Moved gamepad control to on robot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,53 @@ For example, the `DrivePlugin` reacts to joystick movements and sends `cmd_vel` 
 
 ---
 
+## Architecture (on-robot manager + operator-station satellite)
+
+The gamepad manager runs **on the robot**, directly in the robot namespace. All of its topics, services and
+actions are relative to that namespace (e.g. `joy`, `joy_teleop_profile`, `joy_feedback`, `cmd_vel`, …), and
+plugins create their endpoints with relative names that resolve under the robot namespace. The node simply
+inherits the namespace it is launched into.
+
+Because the gamepad is physically connected to the operator station (OCS), a separate **`joy_satellite`** node
+runs on the OCS and bridges the two sides:
+
+- It forwards the local `joy` stream to the selected robot's `<target_robot>/joy` topic, so the on-robot
+  manager sees the gamepad input.
+- It bridges the robot's rumble feedback (`<target_robot>/joy_feedback`) back to the local feedback topic that
+  the OCS joy driver subscribes to, and runs a watchdog that forces the gamepad back to rest if the feedback
+  stream stops while rumbling (e.g. after retargeting to an idle robot, or the robot dropping out).
+- The target robot can be changed at runtime via the `set_target_robot` service
+  (`hector_gamepad_manager_msgs/srv/SetTargetRobot`). `target_robot` may be an absolute namespace (leading `/`)
+  or relative to the satellite's own namespace; setting it to `""` disables forwarding.
+
+This split lets a single operator gamepad drive any of several robots by retargeting the satellite, while each
+robot keeps its own manager and per-robot plugin configuration locally.
+
+```mermaid
+flowchart LR
+    subgraph OCS["Operator station"]
+        driver["joy driver"]
+        satellite["joy_satellite"]
+    end
+    subgraph Robot["Robot (namespace &lt;target_robot&gt;)"]
+        manager["hector_gamepad_manager"]
+        plugins["plugins"]
+    end
+
+    driver -- "joy" --> satellite
+    satellite -- "&lt;target_robot&gt;/joy" --> manager
+    manager --> plugins
+    manager -- "&lt;target_robot&gt;/joy_feedback" --> satellite
+    satellite -- "set_feedback (rumble)" --> driver
+
+    retarget(["set_target_robot service<br/>(retarget at runtime)"]) -.-> satellite
+```
+
+The satellite is provided both as a standalone executable (`joy_satellite_node`) and as a composable component
+(`hector_gamepad_manager::JoySatelliteNode`) for loading into a shared OCS container.
+
+---
+
 ## Configuration
 
 The system supports multiple **configurations** for different capabilities, such as **driving**, **manipulation**, or *
@@ -110,11 +157,28 @@ Plugins can then react to input and send commands to the robot.
 
 ## Launch
 
-The hector_gamepad_manager can be launched with the following command:
+The setup has two parts (see [Architecture](#architecture-on-robot-manager--operator-station-satellite)): the
+manager on the robot and the satellite on the operator station.
+
+On the robot, launch the manager into the robot namespace:
 
 ```bash
-ros2 launch hector_gampepad_manager hector_gamepad_manager.launch.yaml
+ros2 launch hector_gamepad_manager hector_gamepad_manager.launch.yaml config_name:=athena
 ```
+
+`config_name` selects the meta-configuration file. The launch file does not set a namespace itself; push it
+into the robot namespace from the surrounding launch (e.g. via `PushRosNamespace`) so the manager's relative
+topics resolve under the robot.
+
+On the operator station, launch the satellite alongside the joy driver:
+
+```bash
+ros2 launch hector_gamepad_manager joy_satellite.launch.yaml target_robot:=/athena
+```
+
+Arguments: `target_robot` (initial robot namespace to forward to, `''` = none), `input_topic` (local joy topic,
+default `joy`) and `feedback_topic` (local rumble topic the joy driver subscribes to, default `joy/set_feedback`).
+Retarget at runtime by calling the `set_target_robot` service.
 
 ## Blackboard
 

--- a/hector_gamepad_manager/CMakeLists.txt
+++ b/hector_gamepad_manager/CMakeLists.txt
@@ -42,17 +42,21 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC ${DEPENDENCIES})
 add_executable(hector_gamepad_manager_node src/hector_gamepad_manager_node.cpp)
 target_link_libraries(hector_gamepad_manager_node PUBLIC ${PROJECT_NAME})
 
-# Operator-station satellite: forwards local joy to the selected robot and bridges feedback back.
+# Operator-station satellite: forwards local joy to the selected robot and
+# bridges feedback back.
 add_executable(joy_satellite_node src/joy_satellite_node.cpp)
-target_include_directories(joy_satellite_node
-                           PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(
+  joy_satellite_node
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 ament_target_dependencies(joy_satellite_node PUBLIC rclcpp sensor_msgs
                           hector_gamepad_manager_msgs)
 
-# Same node exposed as a composable component for loading into a shared container.
+# Same node exposed as a composable component for loading into a shared
+# container.
 add_library(joy_satellite_component SHARED src/joy_satellite_component.cpp)
-target_include_directories(joy_satellite_component
-                           PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(
+  joy_satellite_component
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 ament_target_dependencies(joy_satellite_component rclcpp rclcpp_components
                           sensor_msgs hector_gamepad_manager_msgs)
 rclcpp_components_register_nodes(joy_satellite_component
@@ -65,10 +69,11 @@ install(
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS hector_gamepad_manager_node joy_satellite_node
         DESTINATION lib/${PROJECT_NAME})
-install(TARGETS joy_satellite_component
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin)
+install(
+  TARGETS joy_satellite_component
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
 install(DIRECTORY launch config DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY test/config/ DESTINATION share/${PROJECT_NAME}/test/config)
 
@@ -110,14 +115,16 @@ if(BUILD_TESTING)
       "AMENT_PREFIX_PATH=${PLUGIN_TEST_PREFIX}:${CMAKE_INSTALL_PREFIX}:$ENV{AMENT_PREFIX_PATH}"
   )
 
-  # Satellite test: header-only node compiled directly against the rtest mocks (no plugins).
+  # Satellite test: header-only node compiled directly against the rtest mocks
+  # (no plugins).
   ament_add_gmock(test_joy_satellite test/main.cpp test/test_joy_satellite.cpp)
   target_include_directories(test_joy_satellite
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
   ament_target_dependencies(test_joy_satellite rclcpp sensor_msgs
                             hector_gamepad_manager_msgs rtest)
-  target_link_libraries(test_joy_satellite rtest::publisher_mock
-                        rtest::subscription_mock rtest::service_mock rtest::rtest_common)
+  target_link_libraries(
+    test_joy_satellite rtest::publisher_mock rtest::subscription_mock
+    rtest::service_mock rtest::rtest_common)
 endif()
 
 ament_export_targets(${PROJECT_NAME}-targets)

--- a/hector_gamepad_manager/CMakeLists.txt
+++ b/hector_gamepad_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(hector_gamepad_manager)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -24,6 +24,10 @@ foreach(dependency IN LISTS DEPENDENCIES)
   find_package(${dependency} REQUIRED)
 endforeach()
 
+# Used only by the operator-station joy satellite node (standalone + component).
+find_package(hector_gamepad_manager_msgs REQUIRED)
+find_package(rclcpp_components REQUIRED)
+
 set(HEADERS include/hector_gamepad_manager/hector_gamepad_manager.hpp)
 
 set(SOURCES src/hector_gamepad_manager.cpp)
@@ -38,12 +42,33 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC ${DEPENDENCIES})
 add_executable(hector_gamepad_manager_node src/hector_gamepad_manager_node.cpp)
 target_link_libraries(hector_gamepad_manager_node PUBLIC ${PROJECT_NAME})
 
+# Operator-station satellite: forwards local joy to the selected robot and bridges feedback back.
+add_executable(joy_satellite_node src/joy_satellite_node.cpp)
+target_include_directories(joy_satellite_node
+                           PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+ament_target_dependencies(joy_satellite_node PUBLIC rclcpp sensor_msgs
+                          hector_gamepad_manager_msgs)
+
+# Same node exposed as a composable component for loading into a shared container.
+add_library(joy_satellite_component SHARED src/joy_satellite_component.cpp)
+target_include_directories(joy_satellite_component
+                           PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+ament_target_dependencies(joy_satellite_component rclcpp rclcpp_components
+                          sensor_msgs hector_gamepad_manager_msgs)
+rclcpp_components_register_nodes(joy_satellite_component
+                                 "hector_gamepad_manager::JoySatelliteNode")
+
 install(
   TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}-targets
   LIBRARY DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
-install(TARGETS hector_gamepad_manager_node DESTINATION lib/${PROJECT_NAME})
+install(TARGETS hector_gamepad_manager_node joy_satellite_node
+        DESTINATION lib/${PROJECT_NAME})
+install(TARGETS joy_satellite_component
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)
 install(DIRECTORY launch config DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY test/config/ DESTINATION share/${PROJECT_NAME}/test/config)
 
@@ -84,6 +109,15 @@ if(BUILD_TESTING)
       ENVIRONMENT
       "AMENT_PREFIX_PATH=${PLUGIN_TEST_PREFIX}:${CMAKE_INSTALL_PREFIX}:$ENV{AMENT_PREFIX_PATH}"
   )
+
+  # Satellite test: header-only node compiled directly against the rtest mocks (no plugins).
+  ament_add_gmock(test_joy_satellite test/main.cpp test/test_joy_satellite.cpp)
+  target_include_directories(test_joy_satellite
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  ament_target_dependencies(test_joy_satellite rclcpp sensor_msgs
+                            hector_gamepad_manager_msgs rtest)
+  target_link_libraries(test_joy_satellite rtest::publisher_mock
+                        rtest::subscription_mock rtest::service_mock rtest::rtest_common)
 endif()
 
 ament_export_targets(${PROJECT_NAME}-targets)

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -63,8 +63,7 @@ private:
     std::unordered_map<int, FunctionMapping> axis_mappings;
   };
 
-  rclcpp::Node::SharedPtr robot_ns_node_;
-  rclcpp::Node::SharedPtr ocs_ns_node_;
+  rclcpp::Node::SharedPtr node_;
 
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
 
@@ -87,12 +86,6 @@ private:
 
   // Config directory relative to package share or absolute path override
   std::string config_directory_;
-
-  // used for to prefix the configs
-  std::string robot_namespace_;
-
-  // namespace for the operator station
-  std::string ocs_namespace_;
 
   // Map of loaded plugins
   std::unordered_map<std::string, std::shared_ptr<GamepadFunctionPlugin>> plugins_;

--- a/hector_gamepad_manager/include/hector_gamepad_manager/joy_satellite.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/joy_satellite.hpp
@@ -1,0 +1,203 @@
+#ifndef HECTOR_GAMEPAD_MANAGER_JOY_SATELLITE_HPP
+#define HECTOR_GAMEPAD_MANAGER_JOY_SATELLITE_HPP
+
+#include <chrono>
+
+#include <hector_gamepad_manager_msgs/srv/set_target_robot.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+#include <sensor_msgs/msg/joy_feedback.hpp>
+
+namespace hector_gamepad_manager
+{
+/**
+ * @brief Operator-station bridge between the local gamepad and the currently selected robot.
+ *
+ * Forwards the local joy stream to the selected robot's `joy` topic and bridges that robot's rumble
+ * feedback (`<target_robot>/joy_feedback`) back to the local feedback topic. `target_robot` may be
+ * an absolute namespace (leading `/`) or one relative to this node's namespace. The selected robot
+ * is changed at runtime via the `set_target_robot` service.
+ *
+ * If the selected robot stops sending feedback while the gamepad is rumbling (e.g. after switching
+ * to an idle robot, or the robot dropping out), a watchdog forces the gamepad back to rest after
+ * `feedback_timeout_sec`.
+ *
+ * Thread-safety: all callbacks (joy/feedback subscriptions, watchdog timer, service) share one
+ * MutuallyExclusive callback group, so they never run concurrently even under a MultiThreadedExecutor
+ * (e.g. when this node is loaded as a component into a shared multi-threaded container). Swapping the
+ * target publisher and feedback subscription inside the service callback is therefore race-free.
+ */
+class JoySatelliteNode : public rclcpp::Node
+{
+public:
+  explicit JoySatelliteNode( const rclcpp::NodeOptions &options = rclcpp::NodeOptions() )
+      : rclcpp::Node( "joy_satellite_node", options )
+  {
+    const std::string input_topic = declare_parameter<std::string>( "input_topic", "joy" );
+    const std::string feedback_topic =
+        declare_parameter<std::string>( "feedback_topic", "joy/set_feedback" );
+    const std::string target_robot = declare_parameter<std::string>( "target_robot", "" );
+    double feedback_timeout_sec = declare_parameter<double>( "feedback_timeout_sec", 0.2 );
+    if ( feedback_timeout_sec <= 0.0 ) {
+      RCLCPP_WARN( get_logger(),
+                   "feedback_timeout_sec must be > 0 (got %.3f); falling back to the 0.2 s default",
+                   feedback_timeout_sec );
+      feedback_timeout_sec = 0.2;
+    }
+
+    // All callbacks share one mutually exclusive group so they never run concurrently, even under a
+    // MultiThreadedExecutor (e.g. as a component in a shared multi-threaded container). This keeps
+    // the publisher/subscription swap in the service callback race-free against the joy/feedback
+    // callbacks that read them.
+    callback_group_ = create_callback_group( rclcpp::CallbackGroupType::MutuallyExclusive );
+    rclcpp::SubscriptionOptions subscription_options;
+    subscription_options.callback_group = callback_group_;
+
+    // Reliable: this feedback (including the watchdog's stop) is bridged to the local joy node's
+    // rumble input. A dropped stop would leave the gamepad rumbling, so don't use best-effort here.
+    feedback_publisher_ = create_publisher<sensor_msgs::msg::JoyFeedback>(
+        feedback_topic, rclcpp::QoS( 1 ).reliable() );
+    joy_subscription_ = create_subscription<sensor_msgs::msg::Joy>(
+        input_topic, rclcpp::QoS( 1 ),
+        [this]( sensor_msgs::msg::Joy::SharedPtr msg ) { forwardJoy( std::move( msg ) ); },
+        subscription_options );
+
+    // Rumble watchdog. Re-armed on each non-zero feedback message and fired once if no fresh
+    // feedback arrives within the timeout (see bridgeFeedback / onFeedbackTimeout). Starts disarmed.
+    const auto feedback_timeout = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>( feedback_timeout_sec ) );
+    feedback_timeout_timer_ =
+        create_wall_timer( feedback_timeout, [this]() { onFeedbackTimeout(); }, callback_group_ );
+    feedback_timeout_timer_->cancel();
+
+    // An invalid 'target_robot' makes setTarget's create_publisher throw, aborting construction.
+    setTarget( target_robot );
+
+    set_target_service_ = create_service<hector_gamepad_manager_msgs::srv::SetTargetRobot>(
+        "set_target_robot",
+        [this]( const hector_gamepad_manager_msgs::srv::SetTargetRobot::Request::SharedPtr request,
+                hector_gamepad_manager_msgs::srv::SetTargetRobot::Response::SharedPtr response ) {
+          handleSetTargetRobot( request, response );
+        },
+        rclcpp::ServicesQoS(), callback_group_ );
+  }
+
+private:
+  void forwardJoy( sensor_msgs::msg::Joy::SharedPtr msg )
+  {
+    last_joy_ = msg;
+    if ( joy_publisher_ )
+      joy_publisher_->publish( *msg );
+  }
+
+  // Point the joy publisher and feedback subscription at a new robot namespace. Publishes one
+  // neutral (all-zero) joy message to the previously selected robot so it returns to rest.
+  //
+  // No observable state is mutated until the new endpoints exist: if robot_namespace does not yield
+  // a valid topic name, create_publisher/create_subscription throws an rclcpp name-validation
+  // exception BEFORE the old robot is neutralized or the target swapped, leaving the current target
+  // fully untouched. Callers translate that throw into a failed service response (or let it abort
+  // construction). This replaces hand-rolled namespace validation.
+  void setTarget( const std::string &robot_namespace )
+  {
+    if ( robot_namespace == target_robot_ )
+      return;
+
+    if ( robot_namespace.empty() ) {
+      // Detach: neutralize the old robot, then drop the endpoints.
+      if ( joy_publisher_ && last_joy_ )
+        joy_publisher_->publish( makeNeutralJoy() );
+      target_robot_ = robot_namespace;
+      joy_publisher_.reset();
+      feedback_subscription_.reset();
+      return;
+    }
+
+    // Create (and thereby validate) the new endpoints first; an invalid namespace throws here,
+    // before the old robot is neutralized or any member is reassigned.
+    rclcpp::SubscriptionOptions subscription_options;
+    subscription_options.callback_group = callback_group_;
+    auto new_publisher =
+        create_publisher<sensor_msgs::msg::Joy>( robot_namespace + "/joy", rclcpp::QoS( 1 ) );
+    auto new_feedback_subscription = create_subscription<sensor_msgs::msg::JoyFeedback>(
+        robot_namespace + "/joy_feedback", rclcpp::QoS( 1 ),
+        [this]( sensor_msgs::msg::JoyFeedback::SharedPtr msg ) {
+          bridgeFeedback( std::move( msg ) );
+        },
+        subscription_options );
+
+    // New target is valid: neutralize the old robot, then swap.
+    if ( joy_publisher_ && last_joy_ )
+      joy_publisher_->publish( makeNeutralJoy() );
+    target_robot_ = robot_namespace;
+    joy_publisher_ = std::move( new_publisher );
+    feedback_subscription_ = std::move( new_feedback_subscription );
+  }
+
+  // Bridge the selected robot's feedback to the local gamepad and (re)arm the watchdog so
+  // the gamepad is forced back to rest if the feedback stream stops while still active.
+  void bridgeFeedback( sensor_msgs::msg::JoyFeedback::SharedPtr msg )
+  {
+    feedback_publisher_->publish( *msg );
+    if ( msg->intensity > 0.0f )
+      feedback_timeout_timer_->reset(); // restart the timeout countdown
+    else
+      feedback_timeout_timer_->cancel(); // already at rest, no watchdog needed
+  }
+
+  // Watchdog: no fresh feedback arrived within the timeout while active → stop the gamepad once.
+  void onFeedbackTimeout()
+  {
+    feedback_timeout_timer_->cancel(); // one-shot until the next non-zero feedback re-arms it
+    sensor_msgs::msg::JoyFeedback stop;
+    stop.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
+    stop.id = 0; // all motors
+    stop.intensity = 0.0f;
+    feedback_publisher_->publish( stop );
+  }
+
+  // A zeroed copy of the last forwarded joy message, so its axis/button counts match the gamepad.
+  // Only called after at least one joy has been forwarded (the caller guards on last_joy_).
+  sensor_msgs::msg::Joy makeNeutralJoy() const
+  {
+    sensor_msgs::msg::Joy neutral;
+    neutral.header.stamp = now();
+    neutral.axes.assign( last_joy_->axes.size(), 0.0f );
+    neutral.buttons.assign( last_joy_->buttons.size(), 0 );
+    return neutral;
+  }
+
+  void handleSetTargetRobot(
+      const hector_gamepad_manager_msgs::srv::SetTargetRobot::Request::SharedPtr request,
+      hector_gamepad_manager_msgs::srv::SetTargetRobot::Response::SharedPtr response )
+  {
+    try {
+      setTarget( request->robot_namespace );
+    } catch ( const std::exception &e ) {
+      // Invalid namespace → create_publisher/create_subscription threw; report it and keep target.
+      response->success = false;
+      response->message =
+          "'" + request->robot_namespace + "' is not a valid robot namespace: " + e.what();
+      RCLCPP_WARN( get_logger(), "Rejected set_target_robot request for '%s': %s",
+                   request->robot_namespace.c_str(), e.what() );
+      return;
+    }
+    response->success = true;
+    response->message = "Forwarding gamepad input to '" + target_robot_ + "'";
+    RCLCPP_INFO( get_logger(), "Now forwarding gamepad input to robot '%s'", target_robot_.c_str() );
+  }
+
+  std::string target_robot_;
+  sensor_msgs::msg::Joy::SharedPtr last_joy_;
+
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscription_;
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr joy_publisher_;
+  rclcpp::Subscription<sensor_msgs::msg::JoyFeedback>::SharedPtr feedback_subscription_;
+  rclcpp::Publisher<sensor_msgs::msg::JoyFeedback>::SharedPtr feedback_publisher_;
+  rclcpp::TimerBase::SharedPtr feedback_timeout_timer_;
+  rclcpp::Service<hector_gamepad_manager_msgs::srv::SetTargetRobot>::SharedPtr set_target_service_;
+};
+} // namespace hector_gamepad_manager
+
+#endif // HECTOR_GAMEPAD_MANAGER_JOY_SATELLITE_HPP

--- a/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
+++ b/hector_gamepad_manager/launch/hector_gamepad_manager.launch.yaml
@@ -2,13 +2,6 @@ launch:
 - arg:
     # Meta Config File that determines which buttons activate which config
     name: config_name
-    default: athena
-- arg:
-    name: robot_namespace
-    default: athena
-- arg:
-    name: ocs_namespace
-    default: ocs
 
 - node:
     pkg: hector_gamepad_manager
@@ -18,8 +11,4 @@ launch:
     param:
     - name: config_name
       value: $(var config_name)
-    - name: robot_namespace
-      value: $(var robot_namespace)
-    - name: ocs_namespace
-      value: $(var ocs_namespace)
     - from: $(find-pkg-share hector_gamepad_manager)/config/$(var config_name)_plugin_config.yaml

--- a/hector_gamepad_manager/launch/joy_satellite.launch.yaml
+++ b/hector_gamepad_manager/launch/joy_satellite.launch.yaml
@@ -4,7 +4,7 @@ launch:
     name: target_robot
     default: ''
 - arg:
-    # Local joy topic published by the operator-station gamepad driver (relative to ocs_namespace).
+    # Local joy topic published by the operator-station gamepad driver (relative to this node's namespace).
     name: input_topic
     default: joy
 - arg:

--- a/hector_gamepad_manager/launch/joy_satellite.launch.yaml
+++ b/hector_gamepad_manager/launch/joy_satellite.launch.yaml
@@ -1,0 +1,26 @@
+launch:
+- arg:
+    # Robot namespace that initially receives the forwarded gamepad input.
+    name: target_robot
+    default: ""
+- arg:
+    # Local joy topic published by the operator-station gamepad driver (relative to ocs_namespace).
+    name: input_topic
+    default: joy
+- arg:
+    # Local feedback topic the operator-station gamepad driver subscribes to for rumble.
+    name: feedback_topic
+    default: joy/set_feedback
+
+- node:
+    pkg: hector_gamepad_manager
+    exec: joy_satellite_node
+    name: joy_satellite_node
+    output: screen
+    param:
+    - name: target_robot
+      value: $(var target_robot)
+    - name: input_topic
+      value: $(var input_topic)
+    - name: feedback_topic
+      value: $(var feedback_topic)

--- a/hector_gamepad_manager/launch/joy_satellite.launch.yaml
+++ b/hector_gamepad_manager/launch/joy_satellite.launch.yaml
@@ -2,7 +2,7 @@ launch:
 - arg:
     # Robot namespace that initially receives the forwarded gamepad input.
     name: target_robot
-    default: ""
+    default: ''
 - arg:
     # Local joy topic published by the operator-station gamepad driver (relative to ocs_namespace).
     name: input_topic

--- a/hector_gamepad_manager/package.xml
+++ b/hector_gamepad_manager/package.xml
@@ -4,15 +4,19 @@
   <name>hector_gamepad_manager</name>
   <version>0.0.0</version>
   <description>Package for managing gamepad inputs</description>
-  <maintainer email="simon.giegerich@stud.tu-darmstadt.de">Simon Giegerich</maintainer>
-  <license>TODO: License declaration</license>
+  <maintainer email="fabian@sim.tu-darmstadt.de">Stefan Fabian</maintainer>
+  <license>MIT</license>
+  <author email="simon.giegerich@stud.tu-darmstadt.de">Simon Giegerich</author>
+  <author email="fabian@sim.tu-darmstadt.de">Stefan Fabian</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>controller_orchestrator</depend>
+  <depend>hector_gamepad_manager_msgs</depend>
   <depend>hector_gamepad_plugin_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>yaml-cpp</depend>
 

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -5,42 +5,36 @@
 namespace hector_gamepad_manager
 {
 HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node )
-    : plugin_loader_( "hector_gamepad_manager",
+    : node_( node ),
+      plugin_loader_( "hector_gamepad_manager",
                       "hector_gamepad_plugin_interface::GamepadFunctionPlugin" ),
       blackboard_( std::make_shared<hector_gamepad_plugin_interface::Blackboard>() ),
       feedback_manager_( std::make_shared<hector_gamepad_plugin_interface::FeedbackManager>() )
 {
   // declare & get parameters
-  node->declare_parameter<std::string>( "config_name", "athena" );
-  node->declare_parameter<std::string>( "config_directory", "config" );
-  node->declare_parameter<std::string>( "robot_namespace", "athena" );
-  node->declare_parameter<std::string>( "ocs_namespace", "ocs" );
-  node->declare_parameter<double>( "double_press_window_sec", 0.25 );
-  const std::string config_switches_filename = node->get_parameter( "config_name" ).as_string();
+  node_->declare_parameter<std::string>( "config_name", "athena" );
+  node_->declare_parameter<std::string>( "config_directory", "config" );
+  node_->declare_parameter<double>( "double_press_window_sec", 0.25 );
+  const std::string config_switches_filename = node_->get_parameter( "config_name" ).as_string();
 
-  robot_namespace_ = node->get_parameter( "robot_namespace" ).as_string();
-  ocs_namespace_ = node->get_parameter( "ocs_namespace" ).as_string();
-  config_directory_ = node->get_parameter( "config_directory" ).as_string();
-  double_press_window_sec_ = node->get_parameter( "double_press_window_sec" ).as_double();
+  config_directory_ = node_->get_parameter( "config_directory" ).as_string();
+  double_press_window_sec_ = node_->get_parameter( "double_press_window_sec" ).as_double();
 
-  // create subnodes: one for the OCS and one for the robot
-  ocs_ns_node_ = node->create_sub_node( ocs_namespace_ );
-  robot_ns_node_ = node->create_sub_node( robot_namespace_ );
-
+  // The node is launched into the robot namespace, so all topics below are robot-namespaced.
   // setup config publisher
   rclcpp::QoS qos_profile( 1 );
   qos_profile.reliability( RMW_QOS_POLICY_RELIABILITY_RELIABLE );
   qos_profile.durability( RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL );
   active_config_publisher_ =
-      ocs_ns_node_->create_publisher<std_msgs::msg::String>( "joy_teleop_profile", qos_profile );
-  feedback_manager_->initialize( ocs_ns_node_ );
+      node_->create_publisher<std_msgs::msg::String>( "joy_teleop_profile", qos_profile );
+  feedback_manager_->initialize( node_, "joy_feedback" );
   controller_orchestrator_ =
-      std::make_shared<controller_orchestrator::ControllerOrchestrator>( robot_ns_node_ );
+      std::make_shared<controller_orchestrator::ControllerOrchestrator>( node_ );
   // load meta switch config and all referenced config files
   if ( loadConfigSwitchesConfig( config_switches_filename ) ) {
     switchConfig( default_config_ );
 
-    joy_subscription_ = ocs_ns_node_->create_subscription<sensor_msgs::msg::Joy>(
+    joy_subscription_ = node_->create_subscription<sensor_msgs::msg::Joy>(
         "joy", 1, std::bind( &HectorGamepadManager::joyCallback, this, std::placeholders::_1 ) );
   }
 }
@@ -58,9 +52,9 @@ bool HectorGamepadManager::loadConfigSwitchesConfig( const std::string &file_nam
       if ( config_name.empty() || pkg_name.empty() )
         continue; // skip empty mappings
 
-      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Loading config file %s", config_name.c_str() );
+      RCLCPP_DEBUG( node_->get_logger(), "Loading config file %s", config_name.c_str() );
       if ( !loadConfig( pkg_name, config_name ) ) {
-        RCLCPP_ERROR( ocs_ns_node_->get_logger(), "Failed to load config file %s",
+        RCLCPP_ERROR( node_->get_logger(), "Failed to load config file %s",
                       config_name.c_str() );
         return false;
       }
@@ -68,7 +62,7 @@ bool HectorGamepadManager::loadConfigSwitchesConfig( const std::string &file_nam
     }
     default_config_ = config["default_config"].as<std::string>();
   } catch ( const std::exception &e ) {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "Error loading Config Switch YAML file: %s", e.what() );
+    RCLCPP_ERROR( node_->get_logger(), "Error loading Config Switch YAML file: %s", e.what() );
     return false;
   }
   return true;
@@ -89,7 +83,7 @@ bool HectorGamepadManager::loadConfig( const std::string &pkg_name, const std::s
 
     return true;
   } catch ( const std::exception &e ) {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "Error loading YAML file: %s", e.what() );
+    RCLCPP_ERROR( node_->get_logger(), "Error loading YAML file: %s", e.what() );
     return false;
   }
 }
@@ -97,13 +91,13 @@ bool HectorGamepadManager::loadConfig( const std::string &pkg_name, const std::s
 bool HectorGamepadManager::switchConfig( const std::string &config_name )
 {
   if ( configs_.count( config_name ) == 0 ) {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(),
+    RCLCPP_ERROR( node_->get_logger(),
                   "Config %s not found. Cannot switch the gamepad config", config_name.c_str() );
     return false;
   }
   if ( config_name == active_config_ )
     return true;
-  RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Switching from config %s to config: %s",
+  RCLCPP_DEBUG( node_->get_logger(), "Switching from config %s to config: %s",
                 active_config_.c_str(), config_name.c_str() );
   // Must run before deactivatePlugins() and before active_config_ is reassigned.
   flushPendingButtonState();
@@ -122,13 +116,13 @@ bool HectorGamepadManager::ensurePluginLoaded( const std::string &plugin_name )
   try {
     std::shared_ptr<GamepadFunctionPlugin> plugin =
         plugin_loader_.createSharedInstance( plugin_name );
-    plugin->initializePlugin( robot_ns_node_, ocs_ns_node_, plugin_name, blackboard_,
-                              feedback_manager_, controller_orchestrator_ );
+    plugin->initializePlugin( node_, plugin_name, blackboard_, feedback_manager_,
+                              controller_orchestrator_ );
     plugins_[plugin_name] = plugin;
-    RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
+    RCLCPP_DEBUG( node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
     return true;
   } catch ( const std::exception &e ) {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "Failed to load plugin %s: %s", plugin_name.c_str(),
+    RCLCPP_ERROR( node_->get_logger(), "Failed to load plugin %s: %s", plugin_name.c_str(),
                   e.what() );
     return false;
   }
@@ -139,7 +133,7 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
                                                std::unordered_map<int, ButtonFunctionMapping> &mappings )
 {
   if ( !config["buttons"] ) {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "No buttons found in config file" );
+    RCLCPP_ERROR( node_->get_logger(), "No buttons found in config file" );
     return false;
   }
 
@@ -172,7 +166,7 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
 
       // on_press is required as the timeout-flush dispatch target and on_hold/on_release fallback.
       if ( on_press.empty() ) {
-        RCLCPP_WARN( ocs_ns_node_->get_logger(),
+        RCLCPP_WARN( node_->get_logger(),
                      "Button %d in config '%s' has new-format mapping but no on_press "
                      "function. on_press is required (it is the fallback for on_hold/"
                      "on_release and the dispatch target on a single press). Skipping.",
@@ -189,7 +183,7 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
       }
       for ( const auto &event_key : { "on_double_press", "on_hold", "on_release" } ) {
         if ( mapping[event_key] && mapping[event_key]["args"] ) {
-          RCLCPP_WARN( ocs_ns_node_->get_logger(),
+          RCLCPP_WARN( node_->get_logger(),
                        "Per-event args under '%s' on button %d are not supported and will be "
                        "ignored. Move them to a top-level 'args:' block.",
                        event_key, id );
@@ -198,7 +192,7 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
     } else {
       // Legacy flat format: plugin + function at top level → treat as on_press
       if ( !mapping["function"] ) {
-        RCLCPP_WARN( ocs_ns_node_->get_logger(),
+        RCLCPP_WARN( node_->get_logger(),
                      "Button %d in config '%s' has 'plugin' but no 'function'. Skipping.", id,
                      config_name.c_str() );
         continue;
@@ -242,7 +236,7 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
       }
     }
   } else {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(), "No %s found in config file", type.c_str() );
+    RCLCPP_ERROR( node_->get_logger(), "No %s found in config file", type.c_str() );
     return false;
   }
   return true;
@@ -268,7 +262,7 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
   if ( handleConfigurationSwitches( inputs ) )
     return;
 
-  const auto now = ocs_ns_node_->now();
+  const auto now = node_->now();
 
   // Handle buttons with double-press detection
   for ( const auto &[button_id, mapping] : configs_[active_config_].button_mappings ) {
@@ -371,7 +365,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
 {
   // activate all  plugins present in the button_mappings_ and axis_mappings_ of the given config
   if ( configs_.count( config_name ) == 0 ) {
-    RCLCPP_ERROR( ocs_ns_node_->get_logger(),
+    RCLCPP_ERROR( node_->get_logger(),
                   "Config %s not found. Cannot activate the gamepad config", config_name.c_str() );
     return;
   }
@@ -379,7 +373,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &button_mapping : configs_[config_name].button_mappings ) {
     if ( !button_mapping.second.plugin->isActive() ) {
       button_mapping.second.plugin->activate();
-      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Activated plugin: %s",
+      RCLCPP_DEBUG( node_->get_logger(), "Activated plugin: %s",
                     button_mapping.second.plugin->getPluginName().c_str() );
       active_plugins_.push_back( button_mapping.second.plugin );
     }
@@ -388,7 +382,7 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
   for ( const auto &axis_mapping : configs_[config_name].axis_mappings ) {
     if ( !axis_mapping.second.plugin->isActive() ) {
       axis_mapping.second.plugin->activate();
-      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Activated plugin: %s",
+      RCLCPP_DEBUG( node_->get_logger(), "Activated plugin: %s",
                     axis_mapping.second.plugin->getPluginName().c_str() );
       active_plugins_.push_back( axis_mapping.second.plugin );
     }
@@ -400,7 +394,7 @@ void HectorGamepadManager::deactivatePlugins()
   for ( const auto &plugin : plugins_ ) {
     if ( plugin.second->isActive() ) {
       plugin.second->deactivate();
-      RCLCPP_DEBUG( ocs_ns_node_->get_logger(), "Deactivated plugin: %s", plugin.first.c_str() );
+      RCLCPP_DEBUG( node_->get_logger(), "Deactivated plugin: %s", plugin.first.c_str() );
     }
   }
   active_plugins_.clear();

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -5,9 +5,8 @@
 namespace hector_gamepad_manager
 {
 HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node )
-    : node_( node ),
-      plugin_loader_( "hector_gamepad_manager",
-                      "hector_gamepad_plugin_interface::GamepadFunctionPlugin" ),
+    : node_( node ), plugin_loader_( "hector_gamepad_manager",
+                                     "hector_gamepad_plugin_interface::GamepadFunctionPlugin" ),
       blackboard_( std::make_shared<hector_gamepad_plugin_interface::Blackboard>() ),
       feedback_manager_( std::make_shared<hector_gamepad_plugin_interface::FeedbackManager>() )
 {
@@ -54,8 +53,7 @@ bool HectorGamepadManager::loadConfigSwitchesConfig( const std::string &file_nam
 
       RCLCPP_DEBUG( node_->get_logger(), "Loading config file %s", config_name.c_str() );
       if ( !loadConfig( pkg_name, config_name ) ) {
-        RCLCPP_ERROR( node_->get_logger(), "Failed to load config file %s",
-                      config_name.c_str() );
+        RCLCPP_ERROR( node_->get_logger(), "Failed to load config file %s", config_name.c_str() );
         return false;
       }
       config_switch_button_mapping_[id] = config_name;
@@ -91,8 +89,8 @@ bool HectorGamepadManager::loadConfig( const std::string &pkg_name, const std::s
 bool HectorGamepadManager::switchConfig( const std::string &config_name )
 {
   if ( configs_.count( config_name ) == 0 ) {
-    RCLCPP_ERROR( node_->get_logger(),
-                  "Config %s not found. Cannot switch the gamepad config", config_name.c_str() );
+    RCLCPP_ERROR( node_->get_logger(), "Config %s not found. Cannot switch the gamepad config",
+                  config_name.c_str() );
     return false;
   }
   if ( config_name == active_config_ )
@@ -122,8 +120,7 @@ bool HectorGamepadManager::ensurePluginLoaded( const std::string &plugin_name )
     RCLCPP_DEBUG( node_->get_logger(), "Loaded plugin: %s", plugin_name.c_str() );
     return true;
   } catch ( const std::exception &e ) {
-    RCLCPP_ERROR( node_->get_logger(), "Failed to load plugin %s: %s", plugin_name.c_str(),
-                  e.what() );
+    RCLCPP_ERROR( node_->get_logger(), "Failed to load plugin %s: %s", plugin_name.c_str(), e.what() );
     return false;
   }
 }
@@ -365,8 +362,8 @@ void HectorGamepadManager::activatePlugins( const std::string &config_name )
 {
   // activate all  plugins present in the button_mappings_ and axis_mappings_ of the given config
   if ( configs_.count( config_name ) == 0 ) {
-    RCLCPP_ERROR( node_->get_logger(),
-                  "Config %s not found. Cannot activate the gamepad config", config_name.c_str() );
+    RCLCPP_ERROR( node_->get_logger(), "Config %s not found. Cannot activate the gamepad config",
+                  config_name.c_str() );
     return;
   }
   // activate all plugins present in the button_mappings_

--- a/hector_gamepad_manager/src/joy_satellite_component.cpp
+++ b/hector_gamepad_manager/src/joy_satellite_component.cpp
@@ -1,0 +1,8 @@
+#include "hector_gamepad_manager/joy_satellite.hpp"
+
+#include <rclcpp_components/register_node_macro.hpp>
+
+// Exposes the same node as the standalone joy_satellite_node executable as a
+// composable component, so it can be loaded into a shared rclcpp_components
+// container (intra-process, single process with other operator-station nodes).
+RCLCPP_COMPONENTS_REGISTER_NODE( hector_gamepad_manager::JoySatelliteNode )

--- a/hector_gamepad_manager/src/joy_satellite_node.cpp
+++ b/hector_gamepad_manager/src/joy_satellite_node.cpp
@@ -1,0 +1,11 @@
+#include "hector_gamepad_manager/joy_satellite.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+int main( int argc, char **argv )
+{
+  rclcpp::init( argc, argv );
+  rclcpp::spin( std::make_shared<hector_gamepad_manager::JoySatelliteNode>() );
+  rclcpp::shutdown();
+  return 0;
+}

--- a/hector_gamepad_manager/test/README.md
+++ b/hector_gamepad_manager/test/README.md
@@ -40,8 +40,8 @@ The file `test/test_hector_gamepad_manager.cpp` creates a single node:
 - `hector_gamepad_manager::HectorGamepadManager` is constructed with that node.
 
 Then the test uses rtest to get:
-- `/ocs/joy` subscription to inject joystick input
-- `/ocs/joy_teleop_profile` publisher to assert config switching
+- `/athena/joy` subscription to inject joystick input
+- `/athena/joy_teleop_profile` publisher to assert config switching
 - `/athena/cmd_vel`, `/athena/moveit_twist_controller/eef_cmd`,
   `/athena/gripper_position_controller/velocity_command`, and
   `/athena/flipper_velocity_controller/commands` publishers to assert output
@@ -59,8 +59,8 @@ Mechanics:
 1) The test ensures the manager is in the "driving" config:
    - It sends a joy message with the "start" button pressed if needed.
    - This triggers the config switch logic inside the manager.
-2) It retrieves the `/ocs/joy` subscription via rtest:
-   - `auto sub_joy = rtest::findSubscription<sensor_msgs::msg::Joy>(node, "/ocs/joy");`
+2) It retrieves the `/athena/joy` subscription via rtest:
+   - `auto sub_joy = rtest::findSubscription<sensor_msgs::msg::Joy>(node, "/athena/joy");`
 3) It retrieves the `/athena/cmd_vel` publisher mock:
    - `auto pub_cmd_vel = rtest::findPublisher<geometry_msgs::msg::TwistStamped>(node, "/athena/cmd_vel");`
 4) It sets an expectation on the publisher mock:
@@ -80,12 +80,12 @@ Why this is reliable:
 
 Goal:
 Verify the active configuration changes are published on
-`/ocs/joy_teleop_profile` in the expected sequence.
+`/athena/joy_teleop_profile` in the expected sequence.
 
 Mechanics:
 1) The test fetches the `joy_teleop_profile` publisher mock:
-   - `auto pub_config = rtest::findPublisher<std_msgs::msg::String>(node, "/ocs/joy_teleop_profile");`
-2) It also fetches the `/ocs/joy` subscription for input injection.
+   - `auto pub_config = rtest::findPublisher<std_msgs::msg::String>(node, "/athena/joy_teleop_profile");`
+2) It also fetches the `/athena/joy` subscription for input injection.
 3) It sets an ordered sequence of expectations:
    - First a publish with `"manipulation"`, then a publish with `"driving"`.
 4) It injects a "back" button press to switch to manipulation.

--- a/hector_gamepad_manager/test/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/test/config/athena_plugin_config.yaml
@@ -2,8 +2,6 @@
   ros__parameters:
     config_name: athena
     config_directory: test/config
-    robot_namespace: athena
-    ocs_namespace: ocs
     drive_plugin:
       slow_factor: 0.3
       fast_factor: 2.0

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_params.yaml
@@ -3,6 +3,4 @@
     use_sim_time: true
     config_name: manager_internal_double_press_switches
     config_directory: test/config
-    robot_namespace: athena
-    ocs_namespace: ocs
     double_press_window_sec: 0.25

--- a/hector_gamepad_manager/test/config/manager_internal_malformed_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed_params.yaml
@@ -2,5 +2,3 @@
   ros__parameters:
     config_name: manager_internal_malformed_switches
     config_directory: test/config
-    robot_namespace: athena
-    ocs_namespace: ocs

--- a/hector_gamepad_manager/test/config/manager_internal_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_params.yaml
@@ -2,5 +2,3 @@
   ros__parameters:
     config_name: manager_internal_switches
     config_directory: test/config
-    robot_namespace: athena
-    ocs_namespace: ocs

--- a/hector_gamepad_manager/test/config/manager_internal_zero_window_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_zero_window_params.yaml
@@ -3,6 +3,4 @@
     use_sim_time: true
     config_name: manager_internal_double_press_switches
     config_directory: test/config
-    robot_namespace: athena
-    ocs_namespace: ocs
     double_press_window_sec: 0.0

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -61,11 +61,11 @@ protected:
     opts_ = rclcpp::NodeOptions();
     opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
 
-    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_test", opts_ );
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_test", "athena", opts_ );
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
-    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_cmd_vel_ =
         rtest::findPublisher<geometry_msgs::msg::TwistStamped>( node_, "/athena/cmd_vel" );
     pub_twist_eef_ = rtest::findPublisher<geometry_msgs::msg::TwistStamped>(

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -65,7 +65,8 @@ protected:
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
     sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
+    pub_config_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_cmd_vel_ =
         rtest::findPublisher<geometry_msgs::msg::TwistStamped>( node_, "/athena/cmd_vel" );
     pub_twist_eef_ = rtest::findPublisher<geometry_msgs::msg::TwistStamped>(

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -52,12 +52,12 @@ protected:
     opts_ = rclcpp::NodeOptions();
     opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
 
-    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_double_press_test", opts_ );
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_double_press_test", "athena", opts_ );
     clock_ = std::make_unique<rtest::TestClock>( node_ );
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
-    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_hold_ =
@@ -395,12 +395,12 @@ protected:
     opts_ = rclcpp::NodeOptions();
     opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
 
-    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_zero_window_test", opts_ );
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_zero_window_test", "athena", opts_ );
     clock_ = std::make_unique<rtest::TestClock>( node_ );
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
-    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_release_ =

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -52,12 +52,14 @@ protected:
     opts_ = rclcpp::NodeOptions();
     opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
 
-    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_double_press_test", "athena", opts_ );
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_double_press_test", "athena",
+                                            opts_ );
     clock_ = std::make_unique<rtest::TestClock>( node_ );
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
     sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
+    pub_config_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_hold_ =
@@ -395,12 +397,14 @@ protected:
     opts_ = rclcpp::NodeOptions();
     opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
 
-    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_zero_window_test", "athena", opts_ );
+    node_ =
+        std::make_shared<rclcpp::Node>( "hector_gamepad_manager_zero_window_test", "athena", opts_ );
     clock_ = std::make_unique<rtest::TestClock>( node_ );
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
     sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
+    pub_config_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_release_ =

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
@@ -47,11 +47,11 @@ protected:
     opts_ = rclcpp::NodeOptions();
     opts_.arguments( { "--ros-args", "--params-file", paramsFilePath() } );
 
-    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_internal_test", opts_ );
+    node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_internal_test", "athena", opts_ );
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
-    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_hold_ =

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
@@ -51,7 +51,8 @@ protected:
     manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
 
     sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
+    pub_config_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_hold_ =

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -51,12 +51,12 @@ protected:
 
     // Construction must not throw, even though the config has malformed entries.
     ASSERT_NO_THROW( {
-      node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_malformed_test", opts_ );
+      node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_malformed_test", "athena", opts_ );
       manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
     } );
 
-    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/ocs/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/ocs/joy_teleop_profile" );
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
+    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_hold_ =

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -51,12 +51,14 @@ protected:
 
     // Construction must not throw, even though the config has malformed entries.
     ASSERT_NO_THROW( {
-      node_ = std::make_shared<rclcpp::Node>( "hector_gamepad_manager_malformed_test", "athena", opts_ );
+      node_ =
+          std::make_shared<rclcpp::Node>( "hector_gamepad_manager_malformed_test", "athena", opts_ );
       manager_ = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node_ );
     } );
 
     sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
-    pub_config_ = rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
+    pub_config_ =
+        rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
     pub_probe_press_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/press" );
     pub_probe_hold_ =

--- a/hector_gamepad_manager/test/test_joy_satellite.cpp
+++ b/hector_gamepad_manager/test/test_joy_satellite.cpp
@@ -89,8 +89,7 @@ TEST_F( JoySatelliteTest, BridgesFeedbackBack )
   sensor_msgs::msg::JoyFeedback fb;
   fb.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
   fb.intensity = 0.7f;
-  EXPECT_CALL( *pub_feedback_,
-               publish( Field( &sensor_msgs::msg::JoyFeedback::intensity, 0.7f ) ) )
+  EXPECT_CALL( *pub_feedback_, publish( Field( &sensor_msgs::msg::JoyFeedback::intensity, 0.7f ) ) )
       .Times( 1 );
   sub_feedback_athena_->handle_message( fb );
 }
@@ -105,9 +104,8 @@ TEST_F( JoySatelliteTest, SwitchRetargetsAndNeutralizesOldRobot )
   sub_joy_->handle_message( joy );
 
   // Switching neutralizes the old robot exactly once (all-zero, matching the forwarded layout).
-  EXPECT_CALL( *pub_athena_,
-               publish( AllOf( Field( &sensor_msgs::msg::Joy::axes, Each( 0.0f ) ),
-                               Field( &sensor_msgs::msg::Joy::buttons, Each( 0 ) ) ) ) )
+  EXPECT_CALL( *pub_athena_, publish( AllOf( Field( &sensor_msgs::msg::Joy::axes, Each( 0.0f ) ),
+                                             Field( &sensor_msgs::msg::Joy::buttons, Each( 0 ) ) ) ) )
       .Times( 1 );
 
   const auto response = callSetTarget( "bob" );
@@ -116,8 +114,7 @@ TEST_F( JoySatelliteTest, SwitchRetargetsAndNeutralizesOldRobot )
   // New joy is now routed to the new robot.
   auto pub_bob = rtest::findPublisher<sensor_msgs::msg::Joy>( node_, "/bob/joy" );
   ASSERT_TRUE( pub_bob );
-  EXPECT_CALL( *pub_bob, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) )
-      .Times( 1 );
+  EXPECT_CALL( *pub_bob, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) ).Times( 1 );
   sub_joy_->handle_message( joy );
 }
 
@@ -132,9 +129,8 @@ TEST_F( JoySatelliteTest, EmptyNamespaceDetaches )
   sub_joy_->handle_message( joy );
 
   // Detaching succeeds and neutralizes the previously selected robot exactly once.
-  EXPECT_CALL( *pub_athena_,
-               publish( AllOf( Field( &sensor_msgs::msg::Joy::axes, Each( 0.0f ) ),
-                               Field( &sensor_msgs::msg::Joy::buttons, Each( 0 ) ) ) ) )
+  EXPECT_CALL( *pub_athena_, publish( AllOf( Field( &sensor_msgs::msg::Joy::axes, Each( 0.0f ) ),
+                                             Field( &sensor_msgs::msg::Joy::buttons, Each( 0 ) ) ) ) )
       .Times( 1 );
   const auto response = callSetTarget( "" );
   EXPECT_TRUE( response.success );

--- a/hector_gamepad_manager/test/test_joy_satellite.cpp
+++ b/hector_gamepad_manager/test/test_joy_satellite.cpp
@@ -1,0 +1,162 @@
+#include <gmock/gmock.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rtest/publisher_mock.hpp>
+#include <rtest/service_mock.hpp>
+#include <rtest/subscription_mock.hpp>
+
+#include <sensor_msgs/msg/joy.hpp>
+#include <sensor_msgs/msg/joy_feedback.hpp>
+
+#include <hector_gamepad_manager/joy_satellite.hpp>
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::Each;
+using ::testing::Field;
+using ::testing::SaveArg;
+
+using SetTargetRobot = hector_gamepad_manager_msgs::srv::SetTargetRobot;
+
+// The satellite node is constructed at the root namespace, so its relative topics resolve to
+// "/joy" (input) and "/joy/set_feedback" (rumble out); the robot-facing topics are absolute. It
+// starts targeting "athena" so the robot-facing endpoints exist from construction.
+class JoySatelliteTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<hector_gamepad_manager::JoySatelliteNode> node_;
+  std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Joy>> sub_joy_;
+  std::shared_ptr<rtest::PublisherMock<sensor_msgs::msg::Joy>> pub_athena_;
+  std::shared_ptr<rtest::PublisherMock<sensor_msgs::msg::JoyFeedback>> pub_feedback_;
+  std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::JoyFeedback>> sub_feedback_athena_;
+  std::shared_ptr<rtest::ServiceMock<SetTargetRobot>> srv_;
+
+  void SetUp() override
+  {
+    rclcpp::NodeOptions options;
+    // Absolute target (leading '/'): the robot-facing topics resolve to /athena/joy regardless of
+    // the satellite's own namespace. A relative target (e.g. "athena") is also accepted and would
+    // resolve under the node's namespace instead - see SwitchRetargetsAndNeutralizesOldRobot.
+    options.parameter_overrides( { rclcpp::Parameter( "target_robot", "/athena" ) } );
+    node_ = std::make_shared<hector_gamepad_manager::JoySatelliteNode>( options );
+
+    sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/joy" );
+    pub_athena_ = rtest::findPublisher<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
+    pub_feedback_ =
+        rtest::findPublisher<sensor_msgs::msg::JoyFeedback>( node_, "/joy/set_feedback" );
+    sub_feedback_athena_ =
+        rtest::findSubscription<sensor_msgs::msg::JoyFeedback>( node_, "/athena/joy_feedback" );
+    srv_ = rtest::findService<SetTargetRobot>( node_, "set_target_robot" );
+
+    ASSERT_TRUE( sub_joy_ );
+    ASSERT_TRUE( pub_athena_ );
+    ASSERT_TRUE( pub_feedback_ );
+    ASSERT_TRUE( sub_feedback_athena_ );
+    ASSERT_TRUE( srv_ );
+  }
+
+  static sensor_msgs::msg::Joy makeJoy()
+  {
+    sensor_msgs::msg::Joy joy;
+    joy.axes = { 0.5f, -0.5f };
+    joy.buttons = { 1, 0, 1 };
+    return joy;
+  }
+
+  // Drive the set_target_robot service and return the captured response.
+  SetTargetRobot::Response callSetTarget( const std::string &ns )
+  {
+    auto request = std::make_shared<SetTargetRobot::Request>();
+    request->robot_namespace = ns;
+    SetTargetRobot::Response captured;
+    EXPECT_CALL( *srv_, send_response( _, _ ) ).WillOnce( SaveArg<1>( &captured ) );
+    srv_->handle_request( std::make_shared<rmw_request_id_t>(), request );
+    return captured;
+  }
+};
+
+// Incoming joy is republished to the currently selected robot's joy topic.
+TEST_F( JoySatelliteTest, ForwardsJoyToTarget )
+{
+  auto joy = makeJoy();
+  EXPECT_CALL( *pub_athena_, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) )
+      .Times( 1 );
+  sub_joy_->handle_message( joy );
+}
+
+// The selected robot's rumble feedback is bridged back to the local feedback topic.
+TEST_F( JoySatelliteTest, BridgesFeedbackBack )
+{
+  sensor_msgs::msg::JoyFeedback fb;
+  fb.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
+  fb.intensity = 0.7f;
+  EXPECT_CALL( *pub_feedback_,
+               publish( Field( &sensor_msgs::msg::JoyFeedback::intensity, 0.7f ) ) )
+      .Times( 1 );
+  sub_feedback_athena_->handle_message( fb );
+}
+
+// Switching robots sends one neutral (all-zero) joy to the old robot and routes new joy to the new.
+TEST_F( JoySatelliteTest, SwitchRetargetsAndNeutralizesOldRobot )
+{
+  // Forward a joy first so the neutral on switch matches the gamepad's axis/button layout.
+  auto joy = makeJoy();
+  EXPECT_CALL( *pub_athena_, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) )
+      .Times( 1 );
+  sub_joy_->handle_message( joy );
+
+  // Switching neutralizes the old robot exactly once (all-zero, matching the forwarded layout).
+  EXPECT_CALL( *pub_athena_,
+               publish( AllOf( Field( &sensor_msgs::msg::Joy::axes, Each( 0.0f ) ),
+                               Field( &sensor_msgs::msg::Joy::buttons, Each( 0 ) ) ) ) )
+      .Times( 1 );
+
+  const auto response = callSetTarget( "bob" );
+  EXPECT_TRUE( response.success );
+
+  // New joy is now routed to the new robot.
+  auto pub_bob = rtest::findPublisher<sensor_msgs::msg::Joy>( node_, "/bob/joy" );
+  ASSERT_TRUE( pub_bob );
+  EXPECT_CALL( *pub_bob, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) )
+      .Times( 1 );
+  sub_joy_->handle_message( joy );
+}
+
+// An empty robot namespace detaches: the previously selected robot is neutralized and forwarding
+// stops until a new target is set.
+TEST_F( JoySatelliteTest, EmptyNamespaceDetaches )
+{
+  // Forward a joy first so the detach neutral matches the gamepad layout (and forwarding works).
+  auto joy = makeJoy();
+  EXPECT_CALL( *pub_athena_, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) )
+      .Times( 1 );
+  sub_joy_->handle_message( joy );
+
+  // Detaching succeeds and neutralizes the previously selected robot exactly once.
+  EXPECT_CALL( *pub_athena_,
+               publish( AllOf( Field( &sensor_msgs::msg::Joy::axes, Each( 0.0f ) ),
+                               Field( &sensor_msgs::msg::Joy::buttons, Each( 0 ) ) ) ) )
+      .Times( 1 );
+  const auto response = callSetTarget( "" );
+  EXPECT_TRUE( response.success );
+
+  // With no target selected, further joy is dropped (and must not crash).
+  sub_joy_->handle_message( joy );
+}
+
+// A malformed namespace (would yield an invalid topic name) is rejected without crashing the node,
+// and the current target is kept. Note an absolute namespace like "/athena" is valid (it yields the
+// valid topic "/athena/joy"); only names that produce an invalid topic are rejected.
+TEST_F( JoySatelliteTest, RejectsMalformedNamespace )
+{
+  EXPECT_CALL( *pub_athena_, publish( _ ) ).Times( AnyNumber() );
+  for ( const std::string bad : { "athena/", "robot ns", "1robot", "a//b", "//bob" } ) {
+    const auto response = callSetTarget( bad );
+    EXPECT_FALSE( response.success ) << "namespace '" << bad << "' should be rejected";
+  }
+
+  // Still forwarding to the original target.
+  auto joy = makeJoy();
+  EXPECT_CALL( *pub_athena_, publish( Field( &sensor_msgs::msg::Joy::buttons, joy.buttons ) ) )
+      .Times( 1 );
+  sub_joy_->handle_message( joy );
+}

--- a/hector_gamepad_manager_msgs/CMakeLists.txt
+++ b/hector_gamepad_manager_msgs/CMakeLists.txt
@@ -4,8 +4,7 @@ project(hector_gamepad_manager_msgs)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
-  "srv/SetTargetRobot.srv")
+rosidl_generate_interfaces(${PROJECT_NAME} "srv/SetTargetRobot.srv")
 
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/hector_gamepad_manager_msgs/CMakeLists.txt
+++ b/hector_gamepad_manager_msgs/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+project(hector_gamepad_manager_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/SetTargetRobot.srv")
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/hector_gamepad_manager_msgs/package.xml
+++ b/hector_gamepad_manager_msgs/package.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hector_gamepad_manager_msgs</name>
+  <version>0.0.0</version>
+  <description>Service definitions for the hector gamepad manager</description>
+  <maintainer email="fabian@sim.tu-darmstadt.de">Stefan Fabian</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/hector_gamepad_manager_msgs/srv/SetTargetRobot.srv
+++ b/hector_gamepad_manager_msgs/srv/SetTargetRobot.srv
@@ -1,0 +1,6 @@
+# Retarget the joy satellite to forward gamepad input to a different robot namespace.
+# Set to "" to disable forwarding.
+string robot_namespace
+---
+bool success
+string message

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/blackboard_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/blackboard_plugin.hpp
@@ -51,8 +51,7 @@ private:
   void onHoldRelease( const std::string &var ) const;
   void onSetString( const std::string &var, const std::string &value ) const;
 
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr
-  getOrCreatePublisher( const std::string &topic, const rclcpp::Node::SharedPtr &node );
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr getOrCreatePublisher( const std::string &topic );
 
   bool active_{ false };
   std::unordered_map<std::string, rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr> publishers_;

--- a/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/blackboard_plugin.hpp
+++ b/hector_gamepad_manager_plugins/include/hector_gamepad_manager_plugins/blackboard_plugin.hpp
@@ -21,9 +21,10 @@ namespace hector_gamepad_manager_plugins
  *  - hold:   set true on press, set false on release
  *  - set:    write <value> (string) on press
  *
- * Topic options:
- *  - topic: publishes to robot namespace
- *  - ocs_topic: publishes to OCS namespace (e.g., for UI feedback)
+ * Topic options (both are relative to the robot namespace the node runs in):
+ *  - topic: publishes the new value to this topic
+ *  - ocs_topic: optional second topic the new value is also published to (e.g. for UI feedback);
+ *               ignored if empty or equal to topic
  */
 class BlackboardPlugin final : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
 {

--- a/hector_gamepad_manager_plugins/src/battery_monitor_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/battery_monitor_plugin.cpp
@@ -115,8 +115,10 @@ void BatteryMonitorPlugin::initialize( const rclcpp::Node::SharedPtr &node )
 
 void BatteryMonitorPlugin::trySubscribe()
 {
-  std::string topic_name = node_->get_effective_namespace();
-  topic_name += "/battery";
+  // "battery" is relative to the node namespace; let rclcpp resolve it to a fully-qualified name so
+  // the graph lookup and the subscription use the same valid name in any namespace.
+  const std::string topic_name =
+      node_->get_node_base_interface()->resolve_topic_or_service_name( "battery", false );
 
   // Check if topic exists in the ROS graph
   const auto topics = node_->get_topic_names_and_types();

--- a/hector_gamepad_manager_plugins/src/blackboard_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/blackboard_plugin.cpp
@@ -68,11 +68,11 @@ void BlackboardPlugin::handleRelease( const std::string &function, const std::st
 }
 
 rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr
-BlackboardPlugin::getOrCreatePublisher( const std::string &topic, const rclcpp::Node::SharedPtr &node )
+BlackboardPlugin::getOrCreatePublisher( const std::string &topic )
 {
   if ( publishers_.find( topic ) == publishers_.end() ) {
     const auto qos = rclcpp::QoS( rclcpp::KeepLast( 10 ) ).transient_local().reliable();
-    publishers_[topic] = node->create_publisher<std_msgs::msg::Bool>( topic, qos );
+    publishers_[topic] = node_->create_publisher<std_msgs::msg::Bool>( topic, qos );
   }
   return publishers_[topic];
 }
@@ -89,12 +89,12 @@ void BlackboardPlugin::onToggle( const std::string &var, const std::string &topi
 
   // Publish to robot namespace topic if specified
   if ( !topic.empty() ) {
-    getOrCreatePublisher( topic, node_ )->publish( msg );
+    getOrCreatePublisher( topic )->publish( msg );
   }
 
-  // Publish to OCS namespace topic if specified
-  if ( !ocs_topic.empty() ) {
-    getOrCreatePublisher( ocs_topic, ocs_ns_node_ )->publish( msg );
+  // Publish to an optional separate OCS-facing topic if specified
+  if ( !ocs_topic.empty() && ocs_topic != topic ) {
+    getOrCreatePublisher( ocs_topic )->publish( msg );
   }
 
   RCLCPP_DEBUG( node_->get_logger(), "[blackboard_plugin] toggle %s -> %s", var.c_str(),

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -47,13 +47,13 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   // Setup Flipper Command Publisher
   const std::string command_topic =
       node_->get_parameter( plugin_namespace + ".command_topic" ).as_string();
-  flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
-      command_topic, 10 );
+  flipper_command_publisher_ =
+      node_->create_publisher<std_msgs::msg::Float64MultiArray>( command_topic, 10 );
 
   // Action clients for flipper group actions
   node_->declare_parameter<std::string>(
       plugin_namespace + ".drive_flipper_action",
-       "flipper_velocity_to_position_controller/drive_flipper_group" );
+      "flipper_velocity_to_position_controller/drive_flipper_group" );
   node_->declare_parameter<std::string>(
       plugin_namespace + ".sync_flipper_action",
       "flipper_velocity_to_position_controller/sync_flipper_group" );

--- a/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/flipper_plugin.cpp
@@ -48,16 +48,15 @@ void FlipperPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   const std::string command_topic =
       node_->get_parameter( plugin_namespace + ".command_topic" ).as_string();
   flipper_command_publisher_ = node_->create_publisher<std_msgs::msg::Float64MultiArray>(
-      "/" + node_->get_parameter( "robot_namespace" ).as_string() + "/" + command_topic, 10 );
+      command_topic, 10 );
 
   // Action clients for flipper group actions
-  const std::string robot_ns = node_->get_parameter( "robot_namespace" ).as_string();
   node_->declare_parameter<std::string>(
       plugin_namespace + ".drive_flipper_action",
-      "/" + robot_ns + "/flipper_velocity_to_position_controller/drive_flipper_group" );
+       "flipper_velocity_to_position_controller/drive_flipper_group" );
   node_->declare_parameter<std::string>(
       plugin_namespace + ".sync_flipper_action",
-      "/" + robot_ns + "/flipper_velocity_to_position_controller/sync_flipper_group" );
+      "flipper_velocity_to_position_controller/sync_flipper_group" );
 
   drive_flipper_client_ = rclcpp_action::create_client<DriveFlipperGroupAction>(
       node_, node_->get_parameter( plugin_namespace + ".drive_flipper_action" ).as_string() );

--- a/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/moveit_plugin.cpp
@@ -35,8 +35,8 @@ void MoveitPlugin::initialize( const rclcpp::Node::SharedPtr &node )
   // setup action client
   node_->declare_parameter<std::string>( plugin_name + ".action_topic", "move_action" );
   const auto action_topic = node_->get_parameter( plugin_name + ".action_topic" ).as_string();
-  action_client_ = rclcpp_action::create_client<moveit_msgs::action::MoveGroup>(
-      node_, node_->get_effective_namespace() + "/" + action_topic );
+  action_client_ =
+      rclcpp_action::create_client<moveit_msgs::action::MoveGroup>( node_, action_topic );
 
   // setup vibration feedback patterns
   const std::string success_pattern_ns = plugin_name + ".vibration_success";

--- a/hector_gamepad_manager_plugins/src/virtual_camera_plugin.cpp
+++ b/hector_gamepad_manager_plugins/src/virtual_camera_plugin.cpp
@@ -125,13 +125,10 @@ void VirtualCameraPlugin::handleRelease( const std::string &function, const std:
 
 void VirtualCameraPlugin::loadCameras()
 {
-  std::string back_topic_name = node_->get_effective_namespace() + "/" + back_camera_topic_name_;
-  std::string front_topic_name = node_->get_effective_namespace() + "/" + front_camera_topic_name_;
-
   front_transform_publisher_ =
-      node_->create_publisher<geometry_msgs::msg::Transform>( front_topic_name, 1 );
+      node_->create_publisher<geometry_msgs::msg::Transform>( front_camera_topic_name_, 1 );
   back_transform_publisher_ =
-      node_->create_publisher<geometry_msgs::msg::Transform>( back_topic_name, 1 );
+      node_->create_publisher<geometry_msgs::msg::Transform>( back_camera_topic_name_, 1 );
 }
 
 void VirtualCameraPlugin::update()

--- a/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
+++ b/hector_gamepad_manager_plugins/test/test_flipper_plugin.cpp
@@ -28,19 +28,20 @@ protected:
 
   void SetUp() override
   {
-    node_ = std::make_shared<rclcpp::Node>( "flipper_plugin_test" );
-    node_->declare_parameter<std::string>( "robot_namespace", "athena" );
+    node_ = std::make_shared<rclcpp::Node>( "flipper_plugin_test", "athena" );
 
     plugin_ = std::make_shared<hector_gamepad_manager_plugins::FlipperPlugin>();
-    plugin_->initializePlugin( node_, node_, "hector_gamepad_manager_plugins::FlipperPlugin",
+    plugin_->initializePlugin( node_, "hector_gamepad_manager_plugins::FlipperPlugin",
                                std::make_shared<hector_gamepad_plugin_interface::Blackboard>(),
                                std::make_shared<hector_gamepad_plugin_interface::FeedbackManager>(),
                                nullptr );
 
+    // The plugin creates the action clients with relative names (resolved under the node namespace
+    // by rclcpp). rtest's action-client mock keys by the unresolved name, so look them up relative.
     drive_mock_ = rtest::experimental::findActionClient<DriveAction>(
-        node_, "/athena/flipper_velocity_to_position_controller/drive_flipper_group" );
+        node_, "flipper_velocity_to_position_controller/drive_flipper_group" );
     sync_mock_ = rtest::experimental::findActionClient<SyncAction>(
-        node_, "/athena/flipper_velocity_to_position_controller/sync_flipper_group" );
+        node_, "flipper_velocity_to_position_controller/sync_flipper_group" );
 
     ASSERT_TRUE( drive_mock_ );
     ASSERT_TRUE( sync_mock_ );

--- a/hector_gamepad_plugin_interface/README.md
+++ b/hector_gamepad_plugin_interface/README.md
@@ -1,38 +1,64 @@
-# hector_gamepad_manager_interface
+# hector_gamepad_plugin_interface
 
-Provides plugin base class for gamepad manager plugins
+Provides the plugin base class (`hector_gamepad_plugin_interface::GamepadFunctionPlugin`) that all
+`hector_gamepad_manager` plugins derive from, plus the shared helpers they use: the `Blackboard`,
+the `FeedbackManager` (rumble), and access to the `controller_orchestrator`.
 
-- [hector_gamepad_manager_interface](#hector_gamepad_manager_interface)
+Plugins are loaded by the manager via `pluginlib` and react to gamepad input by implementing the
+handler methods below. The manager runs on the robot, in the robot namespace, so any ROS endpoints a
+plugin creates on `node_` should use **relative** names — they resolve under the robot namespace.
 
+## Writing a plugin
 
-## `hector_gamepad_manager_interface`
+Derive from `GamepadFunctionPlugin`, export it with `pluginlib`, and implement the relevant methods:
 
-### Subscribed Topics
+```cpp
+class MyPlugin final : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
+{
+  void initialize( const rclcpp::Node::SharedPtr &node ) override;  // set up publishers/clients
+  void handlePress( const std::string &function, const std::string &id ) override;
+  void handleHold( const std::string &function, const std::string &id ) override;
+  void handleRelease( const std::string &function, const std::string &id ) override;
+  void handleAxis( const std::string &function, const std::string &id, double value ) override;
+  void update() override;        // called periodically after inputs are dispatched
+  void activate() override;      // unlock the plugin
+  void deactivate() override;    // lock the plugin and bring it into a safe state
+};
+```
 
-| Topic | Type | Description |
-| --- | --- | --- |
-|  |  |  |
+`function` is the function string from the config (e.g. `drive`, `go_to_pose`); `id` is the config id
+that uniquely scopes the mapping so the same function can be reused multiple times. `update`,
+`activate` and `deactivate` are required; the input handlers are optional (default to no-op).
 
-### Published Topics
+### Lifecycle
 
-| Topic | Type | Description |
-| --- | --- | --- |
-|  |  |  |
+The manager calls `initializePlugin(...)` once when the plugin is loaded. This stores the shared
+resources, sets the plugin id/name/namespace from the registered class name, and then calls the
+plugin's `initialize(node)`. Plugins belonging to the active configuration are `activate()`d; plugins
+of other configurations are `deactivate()`d when switching configs.
 
-### Services
+## Provided to the plugin
 
-| Service | Type | Description |
-| --- | --- | --- |
-|  |  |  |
+Available as protected members after initialization:
 
-### Actions
+| Member | Description |
+| --- | --- |
+| `node_` | ROS node in the robot namespace. Create publishers/subscriptions/clients here with relative names. |
+| `blackboard_` | Shared key/value store for exchanging state between plugins (e.g. `inverted_steering`). |
+| `feedback_manager_` | Triggers gamepad rumble via named vibration patterns. |
+| `controller_orchestrator_` | Activates/queries ros2_control controllers (see helpers below). |
+| `plugin_id_` / `plugin_name_` / `plugin_namespace_` | The registered class name and its split parts (name is converted to `snake_case`). |
+| `active_` | Whether the plugin is currently active. |
+| `button_states_` | Per-function button state used by the default `handleButton` dispatch. |
 
-| Action | Type | Description |
-| --- | --- | --- |
-|  |  |  |
+> **Note:** For buttons configured with `on_double_press`, the manager dispatches
+> `handlePress`/`handleHold`/`handleRelease` directly and bypasses `handleButton`, so `button_states_`
+> does not reflect the physical state of those buttons. See the manager README for details.
 
-### Parameters
+## Helper methods
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-|  |  |  |
+- `getConfigValueOr<T>(id, param, default)` — read an `args` value for this plugin/config from the
+  blackboard, namespaced by plugin id and config id.
+- `activateControllers(names, callback = nullptr)` — switch ros2_control controllers asynchronously.
+- `areControllersActive(names)` — check whether the given controllers are active.
+- `isActive()`, `getPluginId()`, `getPluginName()`, `getPluginNamespace()` — accessors.

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp
@@ -18,18 +18,16 @@ public:
   virtual ~GamepadFunctionPlugin() = default;
 
   void initializePlugin(
-      const rclcpp::Node::SharedPtr &robot_ns_node, const rclcpp::Node::SharedPtr &ocs_ns_node,
-      const std::string &plugin_id, std::shared_ptr<Blackboard> blackboard,
-      std::shared_ptr<FeedbackManager> feedback_manager,
+      const rclcpp::Node::SharedPtr &node, const std::string &plugin_id,
+      std::shared_ptr<Blackboard> blackboard, std::shared_ptr<FeedbackManager> feedback_manager,
       std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator )
   {
-    node_ = robot_ns_node;
-    ocs_ns_node_ = ocs_ns_node;
+    node_ = node;
     blackboard_ = blackboard;
     feedback_manager_ = feedback_manager;
     controller_orchestrator_ = controller_orchestrator;
     setPluginId( plugin_id );
-    initialize( robot_ns_node );
+    initialize( node );
   }
 
   /**
@@ -237,9 +235,6 @@ protected:
   }
   // The ROS node in the robot namespace
   rclcpp::Node::SharedPtr node_;
-
-  // The ROS node in the OCS (operator control station) namespace
-  rclcpp::Node::SharedPtr ocs_ns_node_;
 
   // Specifies if the plugin is active.
   bool active_ = false;

--- a/hector_gamepad_testing_tools/hector_gamepad_testing_tools/fake_joy_publisher.py
+++ b/hector_gamepad_testing_tools/hector_gamepad_testing_tools/fake_joy_publisher.py
@@ -206,14 +206,14 @@ class FakeJoyPublisher(Node):
         # ---- Find the actual manager node FQN (handles random suffixes) ----
         manager_fqn = _find_manager_fqn(self, manager_node_basename)
 
-        # ---- Pull config_name & ocs_namespace from that node ----
-        params = _request_params_sync(
-            self, manager_fqn, ("config_name", "ocs_namespace")
-        )
+        # ---- Pull config_name from that node ----
+        params = _request_params_sync(self, manager_fqn, ("config_name",))
         config_name = params.get("config_name") or "athena"
-        ocs_ns = params.get("ocs_namespace") or "ocs"
+        # The manager runs in the robot namespace; joy and joy_teleop_profile live there. Derive
+        # that namespace from the manager node's FQN ('/<robot_ns>/<node_name>').
+        robot_ns = manager_fqn.rsplit("/", 1)[0] or "/"
         self.get_logger().info(
-            f"Using manager '{manager_fqn}' with config_name='{config_name}', ocs_namespace='{ocs_ns}'"
+            f"Using manager '{manager_fqn}' with config_name='{config_name}', robot_namespace='{robot_ns}'"
         )
 
         # ---- Load meta-config & modes ----
@@ -265,7 +265,7 @@ class FakeJoyPublisher(Node):
         qos_cfg.durability = DurabilityPolicy.TRANSIENT_LOCAL
         self._active_config_sub = self.create_subscription(
             String,
-            f"{ocs_ns.strip('/')}/joy_teleop_profile",
+            f"{robot_ns.strip('/')}/joy_teleop_profile",
             self._active_config_cb,
             qos_cfg,
         )
@@ -284,7 +284,7 @@ class FakeJoyPublisher(Node):
         self._pending_one_shot_keys: Set[Key] = set()
 
         # Publisher
-        topic = f"{ocs_ns.strip('/')}/joy"
+        topic = f"{robot_ns.strip('/')}/joy"
         self._pub = self.create_publisher(Joy, topic, 10)
         self.get_logger().info(f"Publishing Joy on '{topic}' at {self._joy_rate_hz} Hz")
 

--- a/hector_gamepad_testing_tools/test/test_fake_joy_publisher.py
+++ b/hector_gamepad_testing_tools/test/test_fake_joy_publisher.py
@@ -28,8 +28,8 @@ from hector_gamepad_testing_tools.fake_joy_publisher import (
 # Launch the manager only
 # ------------------------
 def generate_test_description():
-    # Configure a clean OCS/robot namespace for the test
-    ocs_ns = "test_ocs"
+    # The manager runs on the robot and is pushed into the robot namespace; all of its topics
+    # (joy, joy_teleop_profile, ...) are scoped under it.
     robot_ns = "test_robot"
     config_name = "athena"
 
@@ -41,12 +41,11 @@ def generate_test_description():
         package="hector_gamepad_manager",
         executable="hector_gamepad_manager_node",
         name="hector_gamepad_manager",
+        namespace=robot_ns,
         output="screen",
         parameters=[
             plugin_cfg,
             {"config_name": config_name},
-            {"ocs_namespace": ocs_ns},
-            {"robot_namespace": robot_ns},
         ],
     )
 
@@ -61,7 +60,6 @@ def generate_test_description():
     )
 
     return ld, {
-        "ocs_ns": ocs_ns,
         "robot_ns": robot_ns,
         "gamepad_manager": gamepad_manager,
     }
@@ -71,9 +69,9 @@ def generate_test_description():
 # Helper test node
 # ------------------------
 class Probe(Node):
-    def __init__(self, ocs_ns: str):
+    def __init__(self, robot_ns: str):
         super().__init__("fake_joy_publisher_test_probe")
-        self.ocs_ns = ocs_ns
+        self.robot_ns = robot_ns
 
         qos_latched = QoSProfile(
             depth=1,
@@ -86,9 +84,9 @@ class Probe(Node):
         self.joy_msgs = deque(maxlen=50)
 
         self.sub_cfg = self.create_subscription(
-            String, f"{ocs_ns}/joy_teleop_profile", self._on_cfg, qos_latched
+            String, f"{robot_ns}/joy_teleop_profile", self._on_cfg, qos_latched
         )
-        self.sub_joy = self.create_subscription(Joy, f"{ocs_ns}/joy", self._on_joy, 10)
+        self.sub_joy = self.create_subscription(Joy, f"{robot_ns}/joy", self._on_joy, 10)
 
     def _on_cfg(self, msg: String):
         self.active_config = msg.data
@@ -132,10 +130,10 @@ class TestFakeJoyPublisher(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         rclpy.init()
-        cls.ocs_ns = "test_ocs"
+        cls.robot_ns = "test_robot"
 
         # Probe to observe /active_config and /joy
-        cls.probe = Probe(cls.ocs_ns)
+        cls.probe = Probe(cls.robot_ns)
 
         # Instantiate the FakeJoyPublisher in-process (so we can call its Python API directly).
         cls.fake = FakeJoyPublisher(joy_rate_hz=40.0)

--- a/hector_gamepad_testing_tools/test/test_fake_joy_publisher.py
+++ b/hector_gamepad_testing_tools/test/test_fake_joy_publisher.py
@@ -86,7 +86,9 @@ class Probe(Node):
         self.sub_cfg = self.create_subscription(
             String, f"{robot_ns}/joy_teleop_profile", self._on_cfg, qos_latched
         )
-        self.sub_joy = self.create_subscription(Joy, f"{robot_ns}/joy", self._on_joy, 10)
+        self.sub_joy = self.create_subscription(
+            Joy, f"{robot_ns}/joy", self._on_joy, 10
+        )
 
     def _on_cfg(self, msg: String):
         self.active_config = msg.data


### PR DESCRIPTION
This is the alternative to #49 
The gamepad control is on the robot, and a joy node satellite runs on the operator station.
I prefer this approach because it offers a cleaner, simpler architecture and allows canceling actions if no joy commands are received from the operator station.
Additionally, this makes it easy to introduce restrictions on a single operator at a time by only processing messages from a single joy publisher.