### PR TITLE
Feature/moveit controller config change

### DIFF
--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -27,7 +27,7 @@
       twist_controller_name: moveit_twist_controller
       gripper_controller_name: gripper_position_controller
     moveit_plugin:
-      start_controllers: [arm_trajectory_controller, gripper_trajectory_controller, flipper_trajectory_controller]
+      start_controllers: [arm_trajectory_controller, flipper_trajectory_controller]
       max_velocity_scaling_factor: 0.1
       max_acceleration_scaling_factor: 0.1
       action_topic: fold_manager_action

--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -28,8 +28,8 @@
       gripper_controller_name: gripper_position_controller
     moveit_plugin:
       start_controllers: [arm_trajectory_controller, flipper_trajectory_controller]
-      max_velocity_scaling_factor: 0.1
-      max_acceleration_scaling_factor: 0.1
+      max_velocity_scaling_factor: 0.2
+      max_acceleration_scaling_factor: 0.2
       action_topic: fold_manager_action
     battery_monitor_plugin:
       cell_voltage_fields:


### PR DESCRIPTION
## Athena Config Update
- do not switch to the gripper controller when starting a moveit action (no listed movegroup controls the flipper)
- increased velocity & acceleration scaling from `0.1` to `0.2`