### PR TITLE
Support the Share button (joy index 11) & make joy parsing robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ buttons:
     args:
       group: "arm_group"
       pose: "folded"
+
+axis_buttons:
+  cross_down: # D-pad down acts as a button
+    plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
+    function: "go_to_pose"
+    args:
+      group: "arm_group"
+      pose: "folded"
 ```
 
 #### Per-Event Button Mapping

--- a/hector_gamepad_manager/config/athena.yaml
+++ b/hector_gamepad_manager/config/athena.yaml
@@ -51,59 +51,60 @@ buttons:
     package: ''
     config: ''
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     package: ''
     config: ''
 
-  13: # Left joystick right
+  left_stick_right:
     package: ''
     config: ''
 
-  14: # Left joystick up
+  left_stick_up:
     package: ''
     config: ''
 
-  15: # Left joystick down
+  left_stick_down:
     package: ''
     config: ''
 
-  16: # LT
+  left_trigger:
     package: ''
     config: ''
 
-  17: # Right joystick left
+  right_stick_left:
     package: ''
     config: ''
 
-  18: # Right joystick right
+  right_stick_right:
     package: ''
     config: ''
 
-  19: # Right joystick up
+  right_stick_up:
     package: ''
     config: ''
 
-  20: # Right joystick down
+  right_stick_down:
     package: ''
     config: ''
 
-  21: # RT
+  right_trigger:
     package: ''
     config: ''
 
-  22: # Cross left
+  cross_left:
     package: ''
     config: ''
 
-  23: # Cross right
+  cross_right:
     package: ''
     config: ''
 
-  24: # Cross up
+  cross_up:
     package: ''
     config: ''
 
-  25: # Cross down
+  cross_down:
     package: ''
     config: ''

--- a/hector_gamepad_manager/config/athena.yaml
+++ b/hector_gamepad_manager/config/athena.yaml
@@ -47,59 +47,63 @@ buttons:
     package: ''
     config: ''
 
+  11: # Button Share (only on newer Xbox controllers)
+    package: ''
+    config: ''
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     package: ''
     config: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     package: ''
     config: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     package: ''
     config: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     package: ''
     config: ''
 
-  15: # LT
+  16: # LT
     package: ''
     config: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     package: ''
     config: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     package: ''
     config: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     package: ''
     config: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     package: ''
     config: ''
 
-  20: # RT
+  21: # RT
     package: ''
     config: ''
 
-  21: # Cross left
+  22: # Cross left
     package: ''
     config: ''
 
-  22: # Cross right
+  23: # Cross right
     package: ''
     config: ''
 
-  23: # Cross up
+  24: # Cross up
     package: ''
     config: ''
 
-  24: # Cross down
+  25: # Cross down
     package: ''
     config: ''

--- a/hector_gamepad_manager/config/athena_plugin_config.yaml
+++ b/hector_gamepad_manager/config/athena_plugin_config.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    config_switch_vibration_enabled: true
     drive_plugin:
       slow_factor: 0.5
       fast_factor: 1.5

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -103,69 +103,70 @@ buttons:
       name: invert_steering
       ocs_topic: joy_teleop_direction
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     plugin: ''
     function: ''
 
-  13: # Left joystick right
+  left_stick_right:
     plugin: ''
     function: ''
 
-  14: # Left joystick up
+  left_stick_up:
     plugin: ''
     function: ''
 
-  15: # Left joystick down
+  left_stick_down:
     plugin: ''
     function: ''
 
-  16: # LT
+  left_trigger:
     plugin: ''
     function: ''
 
-  17: # Right joystick left
+  right_stick_left:
     plugin: ''
     function: ''
 
-  18: # Right joystick right
+  right_stick_right:
     plugin: ''
     function: ''
 
-  19: # Right joystick up
+  right_stick_up:
     plugin: ''
     function: ''
 
-  20: # Right joystick down
+  right_stick_down:
     plugin: ''
     function: ''
 
-  21: # RT
+  right_trigger:
     plugin: ''
     function: ''
 
-  22: # Cross left
+  cross_left:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: tub
 
-  23: # Cross right
+  cross_right:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: compact
 
-  24: # Cross up
+  cross_up:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: up
 
-  25: # Cross down
+  cross_down:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -96,69 +96,76 @@ buttons:
     plugin: hector_gamepad_manager_plugins::VirtualCameraPlugin
     function: reset_camera
 
+  11: # Button Share (only on newer Xbox controllers)
+    plugin: hector_gamepad_manager_plugins::BlackboardPlugin
+    function: toggle
+    args:
+      name: invert_steering
+      ocs_topic: joy_teleop_direction
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     plugin: ''
     function: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     plugin: ''
     function: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     plugin: ''
     function: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     plugin: ''
     function: ''
 
-  15: # LT
+  16: # LT
     plugin: ''
     function: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     plugin: ''
     function: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     plugin: ''
     function: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     plugin: ''
     function: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     plugin: ''
     function: ''
 
-  20: # RT
+  21: # RT
     plugin: ''
     function: ''
 
-  21: # Cross left
+  22: # Cross left
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: tub
 
-  22: # Cross right
+  23: # Cross right
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: compact
 
-  23: # Cross up
+  24: # Cross up
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: up
 
-  24: # Cross down
+  25: # Cross down
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:

--- a/hector_gamepad_manager/config/driving_simple.yaml
+++ b/hector_gamepad_manager/config/driving_simple.yaml
@@ -76,59 +76,63 @@ buttons:
     plugin: ''
     function: ''
 
+  11: # Button Share (only on newer Xbox controllers)
+    plugin: ''
+    function: ''
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     plugin: ''
     function: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     plugin: ''
     function: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     plugin: ''
     function: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     plugin: ''
     function: ''
 
-  15: # LT
+  16: # LT
     plugin: ''
     function: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     plugin: ''
     function: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     plugin: ''
     function: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     plugin: ''
     function: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     plugin: ''
     function: ''
 
-  20: # RT
+  21: # RT
     plugin: ''
     function: ''
 
-  21: # Cross left
+  22: # Cross left
     plugin: ''
     function: ''
 
-  22: # Cross right
+  23: # Cross right
     plugin: ''
     function: ''
 
-  23: # Cross up
+  24: # Cross up
     plugin: ''
     function: ''
 
-  24: # Cross down
+  25: # Cross down
     plugin: ''
     function: ''

--- a/hector_gamepad_manager/config/driving_simple.yaml
+++ b/hector_gamepad_manager/config/driving_simple.yaml
@@ -80,59 +80,60 @@ buttons:
     plugin: ''
     function: ''
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     plugin: ''
     function: ''
 
-  13: # Left joystick right
+  left_stick_right:
     plugin: ''
     function: ''
 
-  14: # Left joystick up
+  left_stick_up:
     plugin: ''
     function: ''
 
-  15: # Left joystick down
+  left_stick_down:
     plugin: ''
     function: ''
 
-  16: # LT
+  left_trigger:
     plugin: ''
     function: ''
 
-  17: # Right joystick left
+  right_stick_left:
     plugin: ''
     function: ''
 
-  18: # Right joystick right
+  right_stick_right:
     plugin: ''
     function: ''
 
-  19: # Right joystick up
+  right_stick_up:
     plugin: ''
     function: ''
 
-  20: # Right joystick down
+  right_stick_down:
     plugin: ''
     function: ''
 
-  21: # RT
+  right_trigger:
     plugin: ''
     function: ''
 
-  22: # Cross left
+  cross_left:
     plugin: ''
     function: ''
 
-  23: # Cross right
+  cross_right:
     plugin: ''
     function: ''
 
-  24: # Cross up
+  cross_up:
     plugin: ''
     function: ''
 
-  25: # Cross down
+  cross_down:
     plugin: ''
     function: ''

--- a/hector_gamepad_manager/config/ec_scout.yaml
+++ b/hector_gamepad_manager/config/ec_scout.yaml
@@ -51,59 +51,60 @@ buttons:
     package: ''
     config: ''
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     package: ''
     config: ''
 
-  13: # Left joystick right
+  left_stick_right:
     package: ''
     config: ''
 
-  14: # Left joystick up
+  left_stick_up:
     package: ''
     config: ''
 
-  15: # Left joystick down
+  left_stick_down:
     package: ''
     config: ''
 
-  16: # LT
+  left_trigger:
     package: ''
     config: ''
 
-  17: # Right joystick left
+  right_stick_left:
     package: ''
     config: ''
 
-  18: # Right joystick right
+  right_stick_right:
     package: ''
     config: ''
 
-  19: # Right joystick up
+  right_stick_up:
     package: ''
     config: ''
 
-  20: # Right joystick down
+  right_stick_down:
     package: ''
     config: ''
 
-  21: # RT
+  right_trigger:
     package: ''
     config: ''
 
-  22: # Cross left
+  cross_left:
     package: ''
     config: ''
 
-  23: # Cross right
+  cross_right:
     package: ''
     config: ''
 
-  24: # Cross up
+  cross_up:
     package: ''
     config: ''
 
-  25: # Cross down
+  cross_down:
     package: ''
     config: ''

--- a/hector_gamepad_manager/config/ec_scout.yaml
+++ b/hector_gamepad_manager/config/ec_scout.yaml
@@ -47,59 +47,63 @@ buttons:
     package: ''
     config: ''
 
+  11: # Button Share (only on newer Xbox controllers)
+    package: ''
+    config: ''
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     package: ''
     config: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     package: ''
     config: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     package: ''
     config: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     package: ''
     config: ''
 
-  15: # LT
+  16: # LT
     package: ''
     config: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     package: ''
     config: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     package: ''
     config: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     package: ''
     config: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     package: ''
     config: ''
 
-  20: # RT
+  21: # RT
     package: ''
     config: ''
 
-  21: # Cross left
+  22: # Cross left
     package: ''
     config: ''
 
-  22: # Cross right
+  23: # Cross right
     package: ''
     config: ''
 
-  23: # Cross up
+  24: # Cross up
     package: ''
     config: ''
 
-  24: # Cross down
+  25: # Cross down
     package: ''
     config: ''

--- a/hector_gamepad_manager/config/ec_scout_plugin_config.yaml
+++ b/hector_gamepad_manager/config/ec_scout_plugin_config.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    config_switch_vibration_enabled: true
     drive_plugin:
       slow_factor: 0.5
       fast_factor: 2.0

--- a/hector_gamepad_manager/config/ec_swift.yaml
+++ b/hector_gamepad_manager/config/ec_swift.yaml
@@ -51,59 +51,60 @@ buttons:
     package: ''
     config: ''
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     package: ''
     config: ''
 
-  13: # Left joystick right
+  left_stick_right:
     package: ''
     config: ''
 
-  14: # Left joystick up
+  left_stick_up:
     package: ''
     config: ''
 
-  15: # Left joystick down
+  left_stick_down:
     package: ''
     config: ''
 
-  16: # LT
+  left_trigger:
     package: ''
     config: ''
 
-  17: # Right joystick left
+  right_stick_left:
     package: ''
     config: ''
 
-  18: # Right joystick right
+  right_stick_right:
     package: ''
     config: ''
 
-  19: # Right joystick up
+  right_stick_up:
     package: ''
     config: ''
 
-  20: # Right joystick down
+  right_stick_down:
     package: ''
     config: ''
 
-  21: # RT
+  right_trigger:
     package: ''
     config: ''
 
-  22: # Cross left
+  cross_left:
     package: ''
     config: ''
 
-  23: # Cross right
+  cross_right:
     package: ''
     config: ''
 
-  24: # Cross up
+  cross_up:
     package: ''
     config: ''
 
-  25: # Cross down
+  cross_down:
     package: ''
     config: ''

--- a/hector_gamepad_manager/config/ec_swift.yaml
+++ b/hector_gamepad_manager/config/ec_swift.yaml
@@ -47,59 +47,63 @@ buttons:
     package: ''
     config: ''
 
+  11: # Button Share (only on newer Xbox controllers)
+    package: ''
+    config: ''
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     package: ''
     config: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     package: ''
     config: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     package: ''
     config: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     package: ''
     config: ''
 
-  15: # LT
+  16: # LT
     package: ''
     config: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     package: ''
     config: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     package: ''
     config: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     package: ''
     config: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     package: ''
     config: ''
 
-  20: # RT
+  21: # RT
     package: ''
     config: ''
 
-  21: # Cross left
+  22: # Cross left
     package: ''
     config: ''
 
-  22: # Cross right
+  23: # Cross right
     package: ''
     config: ''
 
-  23: # Cross up
+  24: # Cross up
     package: ''
     config: ''
 
-  24: # Cross down
+  25: # Cross down
     package: ''
     config: ''

--- a/hector_gamepad_manager/config/ec_swift_plugin_config.yaml
+++ b/hector_gamepad_manager/config/ec_swift_plugin_config.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    config_switch_vibration_enabled: true
     drive_plugin:
       slow_factor: 0.5
       fast_factor: 2.0

--- a/hector_gamepad_manager/config/manipulation.yaml
+++ b/hector_gamepad_manager/config/manipulation.yaml
@@ -64,7 +64,7 @@ buttons:
     plugin: ''
     function: ''
 
-  8: # Button Guide (Manufacturer Button)
+  8: # Button Guide (Manufacturer Button) - fallback for pads without a Share button (unreliable on Xbox Series pads: USB reset on press)
     plugin: hector_gamepad_manager_plugins::BlackboardPlugin
     function: toggle
     args:
@@ -83,48 +83,55 @@ buttons:
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: single_joint_mode
 
+  11: # Button Share (only on newer Xbox controllers)
+    plugin: hector_gamepad_manager_plugins::BlackboardPlugin
+    function: toggle
+    args:
+      name: invert_steering
+      ocs_topic: joy_teleop_direction
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     plugin: ''
     function: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     plugin: ''
     function: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     plugin: ''
     function: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     plugin: ''
     function: ''
 
-  15: # LT
+  16: # LT
     plugin: ''
     function: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     plugin: ''
     function: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     plugin: ''
     function: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     plugin: ''
     function: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     plugin: ''
     function: ''
 
-  20: # RT
+  21: # RT
     plugin: ''
     function: ''
 
-  21: # Cross left
+  22: # Cross left
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
@@ -132,7 +139,7 @@ buttons:
       pose: back
       inverted_pose: front
 
-  22: # Cross right
+  23: # Cross right
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
@@ -140,11 +147,11 @@ buttons:
       pose: front
       inverted_pose: back
 
-  23: # Cross up
+  24: # Cross up
     plugin: ''
     function: ''
 
-  24: # Cross down
+  25: # Cross down
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:

--- a/hector_gamepad_manager/config/manipulation.yaml
+++ b/hector_gamepad_manager/config/manipulation.yaml
@@ -90,48 +90,49 @@ buttons:
       name: invert_steering
       ocs_topic: joy_teleop_direction
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     plugin: ''
     function: ''
 
-  13: # Left joystick right
+  left_stick_right:
     plugin: ''
     function: ''
 
-  14: # Left joystick up
+  left_stick_up:
     plugin: ''
     function: ''
 
-  15: # Left joystick down
+  left_stick_down:
     plugin: ''
     function: ''
 
-  16: # LT
+  left_trigger:
     plugin: ''
     function: ''
 
-  17: # Right joystick left
+  right_stick_left:
     plugin: ''
     function: ''
 
-  18: # Right joystick right
+  right_stick_right:
     plugin: ''
     function: ''
 
-  19: # Right joystick up
+  right_stick_up:
     plugin: ''
     function: ''
 
-  20: # Right joystick down
+  right_stick_down:
     plugin: ''
     function: ''
 
-  21: # RT
+  right_trigger:
     plugin: ''
     function: ''
 
-  22: # Cross left
+  cross_left:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
@@ -139,7 +140,7 @@ buttons:
       pose: back
       inverted_pose: front
 
-  23: # Cross right
+  cross_right:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
@@ -147,11 +148,11 @@ buttons:
       pose: front
       inverted_pose: back
 
-  24: # Cross up
+  cross_up:
     plugin: ''
     function: ''
 
-  25: # Cross down
+  cross_down:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -50,12 +50,17 @@ private:
     rclcpp::Time last_press_time{ 0, 0, RCL_ROS_TIME };
   };
 
+  static constexpr int VIRTUAL_BUTTON_BASE = 32;
+  static constexpr int NUM_VIRTUAL_BUTTONS = 14;
+  static constexpr int NUM_BUTTONS = VIRTUAL_BUTTON_BASE + NUM_VIRTUAL_BUTTONS;
+  static constexpr int NUM_AXES = 8;
+
   // Struct to store the inputs from the gamepad
   struct GamepadInputs {
     // Vector of axes values
-    std::array<float, 8> axes = std::array<float, 8>{ 0.0 };
+    std::array<float, NUM_AXES> axes = std::array<float, NUM_AXES>{ 0.0 };
 
-    std::array<bool, 26> buttons = std::array<bool, 26>{ false };
+    std::array<bool, NUM_BUTTONS> buttons = std::array<bool, NUM_BUTTONS>{ false };
   };
 
   struct GamepadConfig {
@@ -76,7 +81,7 @@ private:
   std::map<std::string, GamepadConfig> configs_;
 
   // Maps buttons to config names
-  std::array<std::string, 26> config_switch_button_mapping_;
+  std::array<std::string, NUM_BUTTONS> config_switch_button_mapping_;
 
   // Name of the active configuration
   std::string active_config_;
@@ -142,19 +147,32 @@ private:
   bool switchConfig( const std::string &config_name );
 
   /**
-   * @brief Initialize the mappings for buttons or axes.
+   * @brief Initialize the button mappings from the "buttons" and "axis_buttons" sections.
    *
    * @param config The YAML node containing the configuration.
-   * @param type The type of the mapping (buttons or axes).
    * @param mappings The mappings to be initialized.
    * @return True if the mappings were initialized successfully, false otherwise.
    */
   bool initButtonMappings( const YAML::Node &config, const std::string &config_name,
                            std::unordered_map<int, ButtonFunctionMapping> &mappings );
 
-  bool initMappings( const YAML::Node &config, const std::string &type,
-                     const std::string &config_name,
-                     std::unordered_map<int, FunctionMapping> &mappings );
+  // Maps "axis_buttons" YAML keys to internal button ids (VIRTUAL_BUTTON_BASE + offset).
+  static const std::map<std::string, int> &axisButtonIds();
+
+  /**
+   * @brief Resolve the physical "buttons" and named "axis_buttons" sections of a config into
+   * (internal button id, mapping node) pairs.
+   *
+   * @return False if the "buttons" section is missing or an axis button name is unknown.
+   * Physical ids outside [0, VIRTUAL_BUTTON_BASE) would overlap the virtual buttons and are
+   * skipped with a warning.
+   */
+  bool collectButtonEntries( const YAML::Node &config,
+                             std::vector<std::pair<int, YAML::Node>> &entries );
+
+  // Initialize the axis mappings from the "axes" section.
+  bool initAxisMappings( const YAML::Node &config, const std::string &config_name,
+                         std::unordered_map<int, FunctionMapping> &mappings );
 
   // Load the named plugin into plugins_ if not already present. Returns false on failure.
   bool ensurePluginLoaded( const std::string &plugin_name );

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -55,7 +55,7 @@ private:
     // Vector of axes values
     std::array<float, 8> axes = std::array<float, 8>{ 0.0 };
 
-    std::array<bool, 25> buttons = std::array<bool, 25>{ false };
+    std::array<bool, 26> buttons = std::array<bool, 26>{ false };
   };
 
   struct GamepadConfig {
@@ -76,7 +76,7 @@ private:
   std::map<std::string, GamepadConfig> configs_;
 
   // Maps buttons to config names
-  std::array<std::string, 25> config_switch_button_mapping_;
+  std::array<std::string, 26> config_switch_button_mapping_;
 
   // Name of the active configuration
   std::string active_config_;

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -435,42 +435,51 @@ HectorGamepadManager::GamepadInputs
 HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::SharedPtr &msg )
 {
   GamepadInputs inputs;
+  // Gamepads differ in how many buttons/axes they report (e.g. the Share button only exists on
+  // newer Xbox controllers), so read out-of-range entries as neutral instead of indexing past the
+  // end of the message arrays.
+  const auto button = [&msg]( const size_t i ) {
+    return i < msg->buttons.size() && msg->buttons[i] != 0;
+  };
+  const auto axis = [&msg]( const size_t i ) { return i < msg->axes.size() ? msg->axes[i] : 0.0f; };
+
   // Axes
-  inputs.axes[0] = msg->axes[0];                    // Left joystick left/right
-  inputs.axes[1] = msg->axes[1];                    // Left joystick up/down
-  inputs.axes[2] = -0.5f * ( msg->axes[2] - 1.0f ); // LT: Change range from [1, -1] to [0, 1]
-  inputs.axes[3] = msg->axes[3];                    // Right joystick left/right
-  inputs.axes[4] = msg->axes[4];                    // Right joystick up/down
-  inputs.axes[5] = -0.5f * ( msg->axes[5] - 1.0f ); // RT: Change range from [1, -1] to [0, 1]
-  inputs.axes[6] = msg->axes[6];                    // Cross left/right
-  inputs.axes[7] = msg->axes[7];                    // Cross up/down
+  inputs.axes[0] = axis( 0 );                    // Left joystick left/right
+  inputs.axes[1] = axis( 1 );                    // Left joystick up/down
+  inputs.axes[2] = -0.5f * ( axis( 2 ) - 1.0f ); // LT: Change range from [1, -1] to [0, 1]
+  inputs.axes[3] = axis( 3 );                    // Right joystick left/right
+  inputs.axes[4] = axis( 4 );                    // Right joystick up/down
+  inputs.axes[5] = -0.5f * ( axis( 5 ) - 1.0f ); // RT: Change range from [1, -1] to [0, 1]
+  inputs.axes[6] = axis( 6 );                    // Cross left/right
+  inputs.axes[7] = axis( 7 );                    // Cross up/down
 
   // Buttons
-  inputs.buttons[0] = msg->buttons[0];   // Button A
-  inputs.buttons[1] = msg->buttons[1];   // Button B
-  inputs.buttons[2] = msg->buttons[2];   // Button X
-  inputs.buttons[3] = msg->buttons[3];   // Button Y
-  inputs.buttons[4] = msg->buttons[4];   // Button LB
-  inputs.buttons[5] = msg->buttons[5];   // Button RB
-  inputs.buttons[6] = msg->buttons[6];   // Button Back
-  inputs.buttons[7] = msg->buttons[7];   // Button Start
-  inputs.buttons[8] = msg->buttons[8];   // Button Guide -> Reserved for config switches
-  inputs.buttons[9] = msg->buttons[9];   // Left joystick pressed
-  inputs.buttons[10] = msg->buttons[10]; // Right joystick pressed
-  inputs.buttons[11] = inputs.axes[0] > AXIS_DEADZONE;  // Left joystick left
-  inputs.buttons[12] = inputs.axes[0] < -AXIS_DEADZONE; // Left joystick right
-  inputs.buttons[13] = inputs.axes[1] > AXIS_DEADZONE;  // Left joystick up
-  inputs.buttons[14] = inputs.axes[1] < -AXIS_DEADZONE; // Left joystick down
-  inputs.buttons[15] = inputs.axes[2] > AXIS_DEADZONE;  // LT button
-  inputs.buttons[16] = inputs.axes[3] > AXIS_DEADZONE;  // Right joystick left
-  inputs.buttons[17] = inputs.axes[3] < -AXIS_DEADZONE; // Right joystick right
-  inputs.buttons[18] = inputs.axes[4] > AXIS_DEADZONE;  // Right joystick up
-  inputs.buttons[19] = inputs.axes[4] < -AXIS_DEADZONE; // Right joystick down
-  inputs.buttons[20] = inputs.axes[5] > AXIS_DEADZONE;  // RT button
-  inputs.buttons[21] = inputs.axes[6] == 1.0f;          // Cross left
-  inputs.buttons[22] = inputs.axes[6] == -1.0f;         // Cross right
-  inputs.buttons[23] = inputs.axes[7] == 1.0f;          // Cross up
-  inputs.buttons[24] = inputs.axes[7] == -1.0f;         // Cross down
+  inputs.buttons[0] = button( 0 );   // Button A
+  inputs.buttons[1] = button( 1 );   // Button B
+  inputs.buttons[2] = button( 2 );   // Button X
+  inputs.buttons[3] = button( 3 );   // Button Y
+  inputs.buttons[4] = button( 4 );   // Button LB
+  inputs.buttons[5] = button( 5 );   // Button RB
+  inputs.buttons[6] = button( 6 );   // Button Back
+  inputs.buttons[7] = button( 7 );   // Button Start
+  inputs.buttons[8] = button( 8 );   // Button Guide (Manufacturer Button)
+  inputs.buttons[9] = button( 9 );   // Left joystick pressed
+  inputs.buttons[10] = button( 10 ); // Right joystick pressed
+  inputs.buttons[11] = button( 11 ); // Button Share (only on newer Xbox controllers)
+  inputs.buttons[12] = inputs.axes[0] > AXIS_DEADZONE;  // Left joystick left
+  inputs.buttons[13] = inputs.axes[0] < -AXIS_DEADZONE; // Left joystick right
+  inputs.buttons[14] = inputs.axes[1] > AXIS_DEADZONE;  // Left joystick up
+  inputs.buttons[15] = inputs.axes[1] < -AXIS_DEADZONE; // Left joystick down
+  inputs.buttons[16] = inputs.axes[2] > AXIS_DEADZONE;  // LT button
+  inputs.buttons[17] = inputs.axes[3] > AXIS_DEADZONE;  // Right joystick left
+  inputs.buttons[18] = inputs.axes[3] < -AXIS_DEADZONE; // Right joystick right
+  inputs.buttons[19] = inputs.axes[4] > AXIS_DEADZONE;  // Right joystick up
+  inputs.buttons[20] = inputs.axes[4] < -AXIS_DEADZONE; // Right joystick down
+  inputs.buttons[21] = inputs.axes[5] > AXIS_DEADZONE;  // RT button
+  inputs.buttons[22] = inputs.axes[6] == 1.0f;          // Cross left
+  inputs.buttons[23] = inputs.axes[6] == -1.0f;         // Cross right
+  inputs.buttons[24] = inputs.axes[7] == 1.0f;          // Cross up
+  inputs.buttons[25] = inputs.axes[7] == -1.0f;         // Cross down
   return inputs;
 }
 

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -7,6 +7,12 @@
 
 namespace hector_gamepad_manager
 {
+namespace
+{
+// One-shot feedback pattern fired whenever the active gamepad config changes.
+constexpr char kConfigSwitchVibrationId[] = "config_switch_vibration";
+} // namespace
+
 HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node )
     : node_( node ), plugin_loader_( "hector_gamepad_manager",
                                      "hector_gamepad_plugin_interface::GamepadFunctionPlugin" ),
@@ -17,6 +23,7 @@ HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node 
   node_->declare_parameter<std::string>( "config_name", "athena" );
   node_->declare_parameter<std::string>( "config_directory", "config" );
   node_->declare_parameter<double>( "double_press_window_sec", 0.25 );
+  node_->declare_parameter<bool>( "config_switch_vibration_enabled", true );
   const std::string config_switches_filename = node_->get_parameter( "config_name" ).as_string();
 
   config_directory_ = node_->get_parameter( "config_directory" ).as_string();
@@ -32,6 +39,15 @@ HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node 
   mapping_publisher_ = node_->create_publisher<hector_gamepad_manager_msgs::msg::GamepadMapping>(
       "joy_mapping", qos_profile );
   feedback_manager_->initialize( node_, "joy_feedback" );
+  // Short rumble confirming a config switch on the gamepad (tunable via the
+  // config_switch_vibration.* parameters). Pulses shorter than ~0.2 s or much weaker than 0.8
+  // are not reliably perceptible on Xbox pads (motor spin-up time).
+  hector_gamepad_plugin_interface::VibrationPatternDefaults config_switch_vibration;
+  config_switch_vibration.on_durations_sec = { 0.25 };
+  config_switch_vibration.off_durations_sec = { 0.0 };
+  config_switch_vibration.intensity = 0.8;
+  config_switch_vibration.cycle = false;
+  feedback_manager_->createVibrationPattern( kConfigSwitchVibrationId, config_switch_vibration );
   controller_orchestrator_ =
       std::make_shared<controller_orchestrator::ControllerOrchestrator>( node_ );
   // load meta switch config and all referenced config files
@@ -112,6 +128,7 @@ bool HectorGamepadManager::switchConfig( const std::string &config_name )
     return true;
   RCLCPP_DEBUG( node_->get_logger(), "Switching from config %s to config: %s",
                 active_config_.c_str(), config_name.c_str() );
+  const bool initial_switch = active_config_.empty();
   // Must run before deactivatePlugins() and before active_config_ is reassigned.
   flushPendingButtonState();
   deactivatePlugins();
@@ -119,6 +136,11 @@ bool HectorGamepadManager::switchConfig( const std::string &config_name )
   active_config_publisher_->publish( std_msgs::msg::String().set__data( config_name ) );
   active_config_ = config_name;
   activatePlugins( config_name );
+  // Confirm the switch with a short rumble; skip the initial activation at startup.
+  // Read on every switch so the feature can be toggled at runtime via `ros2 param set`.
+  if ( !initial_switch && node_->get_parameter( "config_switch_vibration_enabled" ).as_bool() ) {
+    feedback_manager_->setPatternActive( kConfigSwitchVibrationId, true );
+  }
   return true;
 }
 

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -43,9 +43,10 @@ bool HectorGamepadManager::loadConfigSwitchesConfig( const std::string &file_nam
 
   try {
     const YAML::Node config = YAML::LoadFile( getPath( "hector_gamepad_manager", file_name ) );
-    for ( const auto &entry : config["buttons"] ) {
-      const int id = entry.first.as<int>();
-      YAML::Node mapping = entry.second;
+    std::vector<std::pair<int, YAML::Node>> entries;
+    if ( !collectButtonEntries( config, entries ) )
+      return false;
+    for ( const auto &[id, mapping] : entries ) {
       auto config_name = mapping["config"].as<std::string>();
       auto pkg_name = mapping["package"].as<std::string>();
       if ( config_name.empty() || pkg_name.empty() )
@@ -75,7 +76,7 @@ bool HectorGamepadManager::loadConfig( const std::string &pkg_name, const std::s
     configs_[file_name] = GamepadConfig();
 
     if ( !initButtonMappings( config, file_name, configs_[file_name].button_mappings ) ||
-         !initMappings( config, "axes", file_name, configs_[file_name].axis_mappings ) ) {
+         !initAxisMappings( config, file_name, configs_[file_name].axis_mappings ) ) {
       return false;
     }
 
@@ -125,19 +126,81 @@ bool HectorGamepadManager::ensurePluginLoaded( const std::string &plugin_name )
   }
 }
 
-bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
-                                               const std::string &config_name,
-                                               std::unordered_map<int, ButtonFunctionMapping> &mappings )
+const std::map<std::string, int> &HectorGamepadManager::axisButtonIds()
+{
+  // Offsets must match the assignment order in convertJoyToGamepadInputs().
+  static const std::map<std::string, int> ids = {
+      { "left_stick_left", VIRTUAL_BUTTON_BASE + 0 },
+      { "left_stick_right", VIRTUAL_BUTTON_BASE + 1 },
+      { "left_stick_up", VIRTUAL_BUTTON_BASE + 2 },
+      { "left_stick_down", VIRTUAL_BUTTON_BASE + 3 },
+      { "left_trigger", VIRTUAL_BUTTON_BASE + 4 },
+      { "right_stick_left", VIRTUAL_BUTTON_BASE + 5 },
+      { "right_stick_right", VIRTUAL_BUTTON_BASE + 6 },
+      { "right_stick_up", VIRTUAL_BUTTON_BASE + 7 },
+      { "right_stick_down", VIRTUAL_BUTTON_BASE + 8 },
+      { "right_trigger", VIRTUAL_BUTTON_BASE + 9 },
+      { "cross_left", VIRTUAL_BUTTON_BASE + 10 },
+      { "cross_right", VIRTUAL_BUTTON_BASE + 11 },
+      { "cross_up", VIRTUAL_BUTTON_BASE + 12 },
+      { "cross_down", VIRTUAL_BUTTON_BASE + 13 },
+  };
+  return ids;
+}
+
+bool HectorGamepadManager::collectButtonEntries( const YAML::Node &config,
+                                                 std::vector<std::pair<int, YAML::Node>> &entries )
 {
   if ( !config["buttons"] ) {
     RCLCPP_ERROR( node_->get_logger(), "No buttons found in config file" );
     return false;
   }
-
   for ( const auto &entry : config["buttons"] ) {
-    const int id = entry.first.as<int>();
-    const YAML::Node mapping = entry.second;
+    int id = -1;
+    try {
+      id = entry.first.as<int>();
+    } catch ( const YAML::Exception & ) {
+      RCLCPP_ERROR( node_->get_logger(),
+                    "Invalid key '%s' in 'buttons'. Physical buttons use numeric ids; "
+                    "axis-derived buttons go in the named 'axis_buttons' section.",
+                    entry.first.as<std::string>( "" ).c_str() );
+      return false;
+    }
+    if ( id < 0 || id >= VIRTUAL_BUTTON_BASE ) {
+      RCLCPP_WARN( node_->get_logger(),
+                   "Button id %d is outside the physical button range [0, %d) and would overlap "
+                   "the virtual axis buttons (use the named 'axis_buttons' section for those). "
+                   "Skipping.",
+                   id, VIRTUAL_BUTTON_BASE );
+      continue;
+    }
+    entries.emplace_back( id, entry.second );
+  }
+  for ( const auto &entry : config["axis_buttons"] ) {
+    const auto name = entry.first.as<std::string>();
+    const auto &ids = axisButtonIds();
+    const auto it = ids.find( name );
+    if ( it == ids.end() ) {
+      std::string valid_names;
+      for ( const auto &known : ids ) valid_names += known.first + " ";
+      RCLCPP_ERROR( node_->get_logger(), "Unknown axis button '%s'. Valid names: %s", name.c_str(),
+                    valid_names.c_str() );
+      return false;
+    }
+    entries.emplace_back( it->second, entry.second );
+  }
+  return true;
+}
 
+bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
+                                               const std::string &config_name,
+                                               std::unordered_map<int, ButtonFunctionMapping> &mappings )
+{
+  std::vector<std::pair<int, YAML::Node>> entries;
+  if ( !collectButtonEntries( config, entries ) )
+    return false;
+
+  for ( const auto &[id, mapping] : entries ) {
     if ( !mapping["plugin"] )
       continue;
     auto plugin_name = mapping["plugin"].as<std::string>();
@@ -209,13 +272,17 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
   return true;
 }
 
-bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::string &type,
-                                         const std::string &config_name,
-                                         std::unordered_map<int, FunctionMapping> &mappings )
+bool HectorGamepadManager::initAxisMappings( const YAML::Node &config, const std::string &config_name,
+                                             std::unordered_map<int, FunctionMapping> &mappings )
 {
-  if ( config[type] ) {
-    for ( const auto &entry : config[type] ) {
+  if ( config["axes"] ) {
+    for ( const auto &entry : config["axes"] ) {
       int id = entry.first.as<int>();
+      if ( id < 0 || id >= NUM_AXES ) {
+        RCLCPP_WARN( node_->get_logger(),
+                     "Axis id %d is outside the valid range [0, %d). Skipping.", id, NUM_AXES );
+        continue;
+      }
       const YAML::Node mapping = entry.second;
       if ( !mapping["plugin"] || !mapping["function"] )
         continue;
@@ -233,7 +300,7 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
       }
     }
   } else {
-    RCLCPP_ERROR( node_->get_logger(), "No %s found in config file", type.c_str() );
+    RCLCPP_ERROR( node_->get_logger(), "No axes found in config file" );
     return false;
   }
   return true;
@@ -453,33 +520,26 @@ HectorGamepadManager::convertJoyToGamepadInputs( const sensor_msgs::msg::Joy::Sh
   inputs.axes[6] = axis( 6 );                    // Cross left/right
   inputs.axes[7] = axis( 7 );                    // Cross up/down
 
-  // Buttons
-  inputs.buttons[0] = button( 0 );   // Button A
-  inputs.buttons[1] = button( 1 );   // Button B
-  inputs.buttons[2] = button( 2 );   // Button X
-  inputs.buttons[3] = button( 3 );   // Button Y
-  inputs.buttons[4] = button( 4 );   // Button LB
-  inputs.buttons[5] = button( 5 );   // Button RB
-  inputs.buttons[6] = button( 6 );   // Button Back
-  inputs.buttons[7] = button( 7 );   // Button Start
-  inputs.buttons[8] = button( 8 );   // Button Guide (Manufacturer Button)
-  inputs.buttons[9] = button( 9 );   // Left joystick pressed
-  inputs.buttons[10] = button( 10 ); // Right joystick pressed
-  inputs.buttons[11] = button( 11 ); // Button Share (only on newer Xbox controllers)
-  inputs.buttons[12] = inputs.axes[0] > AXIS_DEADZONE;  // Left joystick left
-  inputs.buttons[13] = inputs.axes[0] < -AXIS_DEADZONE; // Left joystick right
-  inputs.buttons[14] = inputs.axes[1] > AXIS_DEADZONE;  // Left joystick up
-  inputs.buttons[15] = inputs.axes[1] < -AXIS_DEADZONE; // Left joystick down
-  inputs.buttons[16] = inputs.axes[2] > AXIS_DEADZONE;  // LT button
-  inputs.buttons[17] = inputs.axes[3] > AXIS_DEADZONE;  // Right joystick left
-  inputs.buttons[18] = inputs.axes[3] < -AXIS_DEADZONE; // Right joystick right
-  inputs.buttons[19] = inputs.axes[4] > AXIS_DEADZONE;  // Right joystick up
-  inputs.buttons[20] = inputs.axes[4] < -AXIS_DEADZONE; // Right joystick down
-  inputs.buttons[21] = inputs.axes[5] > AXIS_DEADZONE;  // RT button
-  inputs.buttons[22] = inputs.axes[6] == 1.0f;          // Cross left
-  inputs.buttons[23] = inputs.axes[6] == -1.0f;         // Cross right
-  inputs.buttons[24] = inputs.axes[7] == 1.0f;          // Cross up
-  inputs.buttons[25] = inputs.axes[7] == -1.0f;         // Cross down
+  // Buttons: physical wire buttons map 1:1, so gamepads with more buttons work without code
+  // changes. Xbox layout: 0=A 1=B 2=X 3=Y 4=LB 5=RB 6=Back 7=Start 8=Guide 9=LeftStickPress
+  // 10=RightStickPress 11=Share (only on newer Xbox controllers).
+  for ( int i = 0; i < VIRTUAL_BUTTON_BASE; i++ ) inputs.buttons[i] = button( i );
+
+  // Axis-derived virtual buttons. Offsets must match axisButtonIds().
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 0] = inputs.axes[0] > AXIS_DEADZONE;  // left_stick_left
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 1] = inputs.axes[0] < -AXIS_DEADZONE; // left_stick_right
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 2] = inputs.axes[1] > AXIS_DEADZONE;  // left_stick_up
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 3] = inputs.axes[1] < -AXIS_DEADZONE; // left_stick_down
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 4] = inputs.axes[2] > AXIS_DEADZONE;  // left_trigger
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 5] = inputs.axes[3] > AXIS_DEADZONE;  // right_stick_left
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 6] = inputs.axes[3] < -AXIS_DEADZONE; // right_stick_right
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 7] = inputs.axes[4] > AXIS_DEADZONE;  // right_stick_up
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 8] = inputs.axes[4] < -AXIS_DEADZONE; // right_stick_down
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 9] = inputs.axes[5] > AXIS_DEADZONE;  // right_trigger
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 10] = inputs.axes[6] == 1.0f;         // cross_left
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 11] = inputs.axes[6] == -1.0f;        // cross_right
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 12] = inputs.axes[7] == 1.0f;         // cross_up
+  inputs.buttons[VIRTUAL_BUTTON_BASE + 13] = inputs.axes[7] == -1.0f;        // cross_down
   return inputs;
 }
 

--- a/hector_gamepad_manager/test/config/athena.yaml
+++ b/hector_gamepad_manager/test/config/athena.yaml
@@ -51,59 +51,60 @@ buttons:
     package: ''
     config: ''
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     package: ''
     config: ''
 
-  13: # Left joystick right
+  left_stick_right:
     package: ''
     config: ''
 
-  14: # Left joystick up
+  left_stick_up:
     package: ''
     config: ''
 
-  15: # Left joystick down
+  left_stick_down:
     package: ''
     config: ''
 
-  16: # LT
+  left_trigger:
     package: ''
     config: ''
 
-  17: # Right joystick left
+  right_stick_left:
     package: ''
     config: ''
 
-  18: # Right joystick right
+  right_stick_right:
     package: ''
     config: ''
 
-  19: # Right joystick up
+  right_stick_up:
     package: ''
     config: ''
 
-  20: # Right joystick down
+  right_stick_down:
     package: ''
     config: ''
 
-  21: # RT
+  right_trigger:
     package: ''
     config: ''
 
-  22: # Cross left
+  cross_left:
     package: ''
     config: ''
 
-  23: # Cross right
+  cross_right:
     package: ''
     config: ''
 
-  24: # Cross up
+  cross_up:
     package: ''
     config: ''
 
-  25: # Cross down
+  cross_down:
     package: ''
     config: ''

--- a/hector_gamepad_manager/test/config/athena.yaml
+++ b/hector_gamepad_manager/test/config/athena.yaml
@@ -47,59 +47,63 @@ buttons:
     package: ''
     config: ''
 
+  11: # Button Share (only on newer Xbox controllers)
+    package: ''
+    config: ''
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     package: ''
     config: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     package: ''
     config: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     package: ''
     config: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     package: ''
     config: ''
 
-  15: # LT
+  16: # LT
     package: ''
     config: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     package: ''
     config: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     package: ''
     config: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     package: ''
     config: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     package: ''
     config: ''
 
-  20: # RT
+  21: # RT
     package: ''
     config: ''
 
-  21: # Cross left
+  22: # Cross left
     package: ''
     config: ''
 
-  22: # Cross right
+  23: # Cross right
     package: ''
     config: ''
 
-  23: # Cross up
+  24: # Cross up
     package: ''
     config: ''
 
-  24: # Cross down
+  25: # Cross down
     package: ''
     config: ''

--- a/hector_gamepad_manager/test/config/driving.yaml
+++ b/hector_gamepad_manager/test/config/driving.yaml
@@ -64,7 +64,7 @@ buttons:
     plugin: ''
     function: ''
 
-  8: # Button Guide (Manufacturer Button)
+  8: # Button Guide (Manufacturer Button) - fallback for pads without a Share button
     plugin: hector_gamepad_manager_plugins::BlackboardPlugin
     function: toggle
     args:
@@ -83,69 +83,76 @@ buttons:
       initial: 'false'
       topic: gamepad_e_stop
 
+  11: # Button Share (only on newer Xbox controllers)
+    plugin: hector_gamepad_manager_plugins::BlackboardPlugin
+    function: toggle
+    args:
+      name: invert_steering
+      initial: 'false'
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     plugin: ''
     function: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     plugin: ''
     function: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     plugin: ''
     function: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     plugin: ''
     function: ''
 
-  15: # LT
+  16: # LT
     plugin: ''
     function: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     plugin: ''
     function: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     plugin: ''
     function: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     plugin: ''
     function: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     plugin: ''
     function: ''
 
-  20: # RT
+  21: # RT
     plugin: ''
     function: ''
 
-  21: # Cross left
+  22: # Cross left
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: tub
 
-  22: # Cross right
+  23: # Cross right
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: compact
 
-  23: # Cross up
+  24: # Cross up
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: up
 
-  24: # Cross down
+  25: # Cross down
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:

--- a/hector_gamepad_manager/test/config/driving.yaml
+++ b/hector_gamepad_manager/test/config/driving.yaml
@@ -90,69 +90,70 @@ buttons:
       name: invert_steering
       initial: 'false'
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     plugin: ''
     function: ''
 
-  13: # Left joystick right
+  left_stick_right:
     plugin: ''
     function: ''
 
-  14: # Left joystick up
+  left_stick_up:
     plugin: ''
     function: ''
 
-  15: # Left joystick down
+  left_stick_down:
     plugin: ''
     function: ''
 
-  16: # LT
+  left_trigger:
     plugin: ''
     function: ''
 
-  17: # Right joystick left
+  right_stick_left:
     plugin: ''
     function: ''
 
-  18: # Right joystick right
+  right_stick_right:
     plugin: ''
     function: ''
 
-  19: # Right joystick up
+  right_stick_up:
     plugin: ''
     function: ''
 
-  20: # Right joystick down
+  right_stick_down:
     plugin: ''
     function: ''
 
-  21: # RT
+  right_trigger:
     plugin: ''
     function: ''
 
-  22: # Cross left
+  cross_left:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: tub
 
-  23: # Cross right
+  cross_right:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: compact
 
-  24: # Cross up
+  cross_up:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:
       group: flipper_group
       pose: up
 
-  25: # Cross down
+  cross_down:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
     args:

--- a/hector_gamepad_manager/test/config/manager_internal.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal.yaml
@@ -28,19 +28,24 @@ buttons:
   11: # Button Share (only on newer Xbox controllers)
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     function: share
-  12:
+  13: # Extra button beyond the Xbox layout (e.g. paddles) - works without code changes
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    function: extra
+
+axis_buttons:
+  left_stick_left:
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     function: virtual
-  13: {plugin: '', function: ''}
-  14: {plugin: '', function: ''}
-  15: {plugin: '', function: ''}
-  16: {plugin: '', function: ''}
-  17: {plugin: '', function: ''}
-  18: {plugin: '', function: ''}
-  19: {plugin: '', function: ''}
-  20: {plugin: '', function: ''}
-  21: {plugin: '', function: ''}
-  22: {plugin: '', function: ''}
-  23: {plugin: '', function: ''}
-  24: {plugin: '', function: ''}
-  25: {plugin: '', function: ''}
+  left_stick_right: {plugin: '', function: ''}
+  left_stick_up: {plugin: '', function: ''}
+  left_stick_down: {plugin: '', function: ''}
+  left_trigger: {plugin: '', function: ''}
+  right_stick_left: {plugin: '', function: ''}
+  right_stick_right: {plugin: '', function: ''}
+  right_stick_up: {plugin: '', function: ''}
+  right_stick_down: {plugin: '', function: ''}
+  right_trigger: {plugin: '', function: ''}
+  cross_left: {plugin: '', function: ''}
+  cross_right: {plugin: '', function: ''}
+  cross_up: {plugin: '', function: ''}
+  cross_down: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal.yaml
@@ -25,10 +25,12 @@ buttons:
   8: {plugin: '', function: ''}
   9: {plugin: '', function: ''}
   10: {plugin: '', function: ''}
-  11:
+  11: # Button Share (only on newer Xbox controllers)
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    function: share
+  12:
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     function: virtual
-  12: {plugin: '', function: ''}
   13: {plugin: '', function: ''}
   14: {plugin: '', function: ''}
   15: {plugin: '', function: ''}
@@ -41,3 +43,4 @@ buttons:
   22: {plugin: '', function: ''}
   23: {plugin: '', function: ''}
   24: {plugin: '', function: ''}
+  25: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_alt.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_alt.yaml
@@ -26,19 +26,21 @@ buttons:
   9: {plugin: '', function: ''}
   10: {plugin: '', function: ''}
   11: {plugin: '', function: ''}
-  12:
+
+axis_buttons:
+  left_stick_left:
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     function: virtual
-  13: {plugin: '', function: ''}
-  14: {plugin: '', function: ''}
-  15: {plugin: '', function: ''}
-  16: {plugin: '', function: ''}
-  17: {plugin: '', function: ''}
-  18: {plugin: '', function: ''}
-  19: {plugin: '', function: ''}
-  20: {plugin: '', function: ''}
-  21: {plugin: '', function: ''}
-  22: {plugin: '', function: ''}
-  23: {plugin: '', function: ''}
-  24: {plugin: '', function: ''}
-  25: {plugin: '', function: ''}
+  left_stick_right: {plugin: '', function: ''}
+  left_stick_up: {plugin: '', function: ''}
+  left_stick_down: {plugin: '', function: ''}
+  left_trigger: {plugin: '', function: ''}
+  right_stick_left: {plugin: '', function: ''}
+  right_stick_right: {plugin: '', function: ''}
+  right_stick_up: {plugin: '', function: ''}
+  right_stick_down: {plugin: '', function: ''}
+  right_trigger: {plugin: '', function: ''}
+  cross_left: {plugin: '', function: ''}
+  cross_right: {plugin: '', function: ''}
+  cross_up: {plugin: '', function: ''}
+  cross_down: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_alt.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_alt.yaml
@@ -25,10 +25,10 @@ buttons:
   8: {plugin: '', function: ''}
   9: {plugin: '', function: ''}
   10: {plugin: '', function: ''}
-  11:
+  11: {plugin: '', function: ''}
+  12:
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     function: virtual
-  12: {plugin: '', function: ''}
   13: {plugin: '', function: ''}
   14: {plugin: '', function: ''}
   15: {plugin: '', function: ''}
@@ -41,3 +41,4 @@ buttons:
   22: {plugin: '', function: ''}
   23: {plugin: '', function: ''}
   24: {plugin: '', function: ''}
+  25: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_bad_axis_name_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_bad_axis_name_params.yaml
@@ -1,0 +1,4 @@
+/**:
+  ros__parameters:
+    config_name: manager_internal_bad_axis_name_switches
+    config_directory: test/config

--- a/hector_gamepad_manager/test/config/manager_internal_bad_axis_name_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_bad_axis_name_switches.yaml
@@ -1,0 +1,7 @@
+# Switches file with an unknown axis button name. Must be rejected at load time.
+default_config: manager_internal
+buttons:
+  7: {package: hector_gamepad_manager, config: manager_internal}
+
+axis_buttons:
+  cross_middle: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
@@ -38,17 +38,19 @@ buttons:
   9: {plugin: '', function: ''}
   10: {plugin: '', function: ''}
   11: {plugin: '', function: ''}
-  12: {plugin: '', function: ''}
-  13: {plugin: '', function: ''}
-  14: {plugin: '', function: ''}
-  15: {plugin: '', function: ''}
-  16: {plugin: '', function: ''}
-  17: {plugin: '', function: ''}
-  18: {plugin: '', function: ''}
-  19: {plugin: '', function: ''}
-  20: {plugin: '', function: ''}
-  21: {plugin: '', function: ''}
-  22: {plugin: '', function: ''}
-  23: {plugin: '', function: ''}
-  24: {plugin: '', function: ''}
-  25: {plugin: '', function: ''}
+
+axis_buttons:
+  left_stick_left: {plugin: '', function: ''}
+  left_stick_right: {plugin: '', function: ''}
+  left_stick_up: {plugin: '', function: ''}
+  left_stick_down: {plugin: '', function: ''}
+  left_trigger: {plugin: '', function: ''}
+  right_stick_left: {plugin: '', function: ''}
+  right_stick_right: {plugin: '', function: ''}
+  right_stick_up: {plugin: '', function: ''}
+  right_stick_down: {plugin: '', function: ''}
+  right_trigger: {plugin: '', function: ''}
+  cross_left: {plugin: '', function: ''}
+  cross_right: {plugin: '', function: ''}
+  cross_up: {plugin: '', function: ''}
+  cross_down: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press.yaml
@@ -51,3 +51,4 @@ buttons:
   22: {plugin: '', function: ''}
   23: {plugin: '', function: ''}
   24: {plugin: '', function: ''}
+  25: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_alt.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_alt.yaml
@@ -22,17 +22,19 @@ buttons:
   9: {plugin: '', function: ''}
   10: {plugin: '', function: ''}
   11: {plugin: '', function: ''}
-  12: {plugin: '', function: ''}
-  13: {plugin: '', function: ''}
-  14: {plugin: '', function: ''}
-  15: {plugin: '', function: ''}
-  16: {plugin: '', function: ''}
-  17: {plugin: '', function: ''}
-  18: {plugin: '', function: ''}
-  19: {plugin: '', function: ''}
-  20: {plugin: '', function: ''}
-  21: {plugin: '', function: ''}
-  22: {plugin: '', function: ''}
-  23: {plugin: '', function: ''}
-  24: {plugin: '', function: ''}
-  25: {plugin: '', function: ''}
+
+axis_buttons:
+  left_stick_left: {plugin: '', function: ''}
+  left_stick_right: {plugin: '', function: ''}
+  left_stick_up: {plugin: '', function: ''}
+  left_stick_down: {plugin: '', function: ''}
+  left_trigger: {plugin: '', function: ''}
+  right_stick_left: {plugin: '', function: ''}
+  right_stick_right: {plugin: '', function: ''}
+  right_stick_up: {plugin: '', function: ''}
+  right_stick_down: {plugin: '', function: ''}
+  right_trigger: {plugin: '', function: ''}
+  cross_left: {plugin: '', function: ''}
+  cross_right: {plugin: '', function: ''}
+  cross_up: {plugin: '', function: ''}
+  cross_down: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_alt.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_alt.yaml
@@ -35,3 +35,4 @@ buttons:
   22: {plugin: '', function: ''}
   23: {plugin: '', function: ''}
   24: {plugin: '', function: ''}
+  25: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
@@ -26,3 +26,4 @@ buttons:
   22: {package: '', config: ''}
   23: {package: '', config: ''}
   24: {package: '', config: ''}
+  25: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_double_press_switches.yaml
@@ -13,17 +13,19 @@ buttons:
   9: {package: '', config: ''}
   10: {package: '', config: ''}
   11: {package: '', config: ''}
-  12: {package: '', config: ''}
-  13: {package: '', config: ''}
-  14: {package: '', config: ''}
-  15: {package: '', config: ''}
-  16: {package: '', config: ''}
-  17: {package: '', config: ''}
-  18: {package: '', config: ''}
-  19: {package: '', config: ''}
-  20: {package: '', config: ''}
-  21: {package: '', config: ''}
-  22: {package: '', config: ''}
-  23: {package: '', config: ''}
-  24: {package: '', config: ''}
-  25: {package: '', config: ''}
+
+axis_buttons:
+  left_stick_left: {package: '', config: ''}
+  left_stick_right: {package: '', config: ''}
+  left_stick_up: {package: '', config: ''}
+  left_stick_down: {package: '', config: ''}
+  left_trigger: {package: '', config: ''}
+  right_stick_left: {package: '', config: ''}
+  right_stick_right: {package: '', config: ''}
+  right_stick_up: {package: '', config: ''}
+  right_stick_down: {package: '', config: ''}
+  right_trigger: {package: '', config: ''}
+  cross_left: {package: '', config: ''}
+  cross_right: {package: '', config: ''}
+  cross_up: {package: '', config: ''}
+  cross_down: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
@@ -36,17 +36,19 @@ buttons:
   9: {plugin: '', function: ''}
   10: {plugin: '', function: ''}
   11: {plugin: '', function: ''}
-  12: {plugin: '', function: ''}
-  13: {plugin: '', function: ''}
-  14: {plugin: '', function: ''}
-  15: {plugin: '', function: ''}
-  16: {plugin: '', function: ''}
-  17: {plugin: '', function: ''}
-  18: {plugin: '', function: ''}
-  19: {plugin: '', function: ''}
-  20: {plugin: '', function: ''}
-  21: {plugin: '', function: ''}
-  22: {plugin: '', function: ''}
-  23: {plugin: '', function: ''}
-  24: {plugin: '', function: ''}
-  25: {plugin: '', function: ''}
+
+axis_buttons:
+  left_stick_left: {plugin: '', function: ''}
+  left_stick_right: {plugin: '', function: ''}
+  left_stick_up: {plugin: '', function: ''}
+  left_stick_down: {plugin: '', function: ''}
+  left_trigger: {plugin: '', function: ''}
+  right_stick_left: {plugin: '', function: ''}
+  right_stick_right: {plugin: '', function: ''}
+  right_stick_up: {plugin: '', function: ''}
+  right_stick_down: {plugin: '', function: ''}
+  right_trigger: {plugin: '', function: ''}
+  cross_left: {plugin: '', function: ''}
+  cross_right: {plugin: '', function: ''}
+  cross_up: {plugin: '', function: ''}
+  cross_down: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
@@ -49,3 +49,4 @@ buttons:
   22: {plugin: '', function: ''}
   23: {plugin: '', function: ''}
   24: {plugin: '', function: ''}
+  25: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed_switches.yaml
@@ -26,3 +26,4 @@ buttons:
   22: {package: '', config: ''}
   23: {package: '', config: ''}
   24: {package: '', config: ''}
+  25: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_malformed_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed_switches.yaml
@@ -13,17 +13,19 @@ buttons:
   9: {package: '', config: ''}
   10: {package: '', config: ''}
   11: {package: '', config: ''}
-  12: {package: '', config: ''}
-  13: {package: '', config: ''}
-  14: {package: '', config: ''}
-  15: {package: '', config: ''}
-  16: {package: '', config: ''}
-  17: {package: '', config: ''}
-  18: {package: '', config: ''}
-  19: {package: '', config: ''}
-  20: {package: '', config: ''}
-  21: {package: '', config: ''}
-  22: {package: '', config: ''}
-  23: {package: '', config: ''}
-  24: {package: '', config: ''}
-  25: {package: '', config: ''}
+
+axis_buttons:
+  left_stick_left: {package: '', config: ''}
+  left_stick_right: {package: '', config: ''}
+  left_stick_up: {package: '', config: ''}
+  left_stick_down: {package: '', config: ''}
+  left_trigger: {package: '', config: ''}
+  right_stick_left: {package: '', config: ''}
+  right_stick_right: {package: '', config: ''}
+  right_stick_up: {package: '', config: ''}
+  right_stick_down: {package: '', config: ''}
+  right_trigger: {package: '', config: ''}
+  cross_left: {package: '', config: ''}
+  cross_right: {package: '', config: ''}
+  cross_up: {package: '', config: ''}
+  cross_down: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_no_rumble_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_no_rumble_params.yaml
@@ -1,0 +1,5 @@
+/**:
+  ros__parameters:
+    config_name: manager_internal_switches
+    config_directory: test/config
+    config_switch_vibration_enabled: false

--- a/hector_gamepad_manager/test/config/manager_internal_overlapping_ids_params.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_overlapping_ids_params.yaml
@@ -1,0 +1,4 @@
+/**:
+  ros__parameters:
+    config_name: manager_internal_overlapping_ids_switches
+    config_directory: test/config

--- a/hector_gamepad_manager/test/config/manager_internal_overlapping_ids_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_overlapping_ids_switches.yaml
@@ -1,0 +1,6 @@
+# Switches file with a physical button id inside the virtual button range (>= 32).
+# The entry must be skipped with a warning; the rest of the config must still load.
+default_config: manager_internal
+buttons:
+  7: {package: hector_gamepad_manager, config: manager_internal}
+  33: {package: hector_gamepad_manager, config: manager_internal_alt}

--- a/hector_gamepad_manager/test/config/manager_internal_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_switches.yaml
@@ -26,3 +26,4 @@ buttons:
   22: {package: '', config: ''}
   23: {package: '', config: ''}
   24: {package: '', config: ''}
+  25: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manager_internal_switches.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_switches.yaml
@@ -13,17 +13,19 @@ buttons:
   9: {package: '', config: ''}
   10: {package: '', config: ''}
   11: {package: '', config: ''}
-  12: {package: '', config: ''}
-  13: {package: '', config: ''}
-  14: {package: '', config: ''}
-  15: {package: '', config: ''}
-  16: {package: '', config: ''}
-  17: {package: '', config: ''}
-  18: {package: '', config: ''}
-  19: {package: '', config: ''}
-  20: {package: '', config: ''}
-  21: {package: '', config: ''}
-  22: {package: '', config: ''}
-  23: {package: '', config: ''}
-  24: {package: '', config: ''}
-  25: {package: '', config: ''}
+
+axis_buttons:
+  left_stick_left: {package: '', config: ''}
+  left_stick_right: {package: '', config: ''}
+  left_stick_up: {package: '', config: ''}
+  left_stick_down: {package: '', config: ''}
+  left_trigger: {package: '', config: ''}
+  right_stick_left: {package: '', config: ''}
+  right_stick_right: {package: '', config: ''}
+  right_stick_up: {package: '', config: ''}
+  right_stick_down: {package: '', config: ''}
+  right_trigger: {package: '', config: ''}
+  cross_left: {package: '', config: ''}
+  cross_right: {package: '', config: ''}
+  cross_up: {package: '', config: ''}
+  cross_down: {package: '', config: ''}

--- a/hector_gamepad_manager/test/config/manipulation.yaml
+++ b/hector_gamepad_manager/test/config/manipulation.yaml
@@ -80,59 +80,60 @@ buttons:
     plugin: ''
     function: ''
 
-  # -------------------- All the axes can also be used as buttons if specified here --------------------
-  12: # Left joystick left
+# -------------------- All the axes can also be used as buttons if specified here --------------------
+axis_buttons:
+  left_stick_left:
     plugin: ''
     function: ''
 
-  13: # Left joystick right
+  left_stick_right:
     plugin: ''
     function: ''
 
-  14: # Left joystick up
+  left_stick_up:
     plugin: ''
     function: ''
 
-  15: # Left joystick down
+  left_stick_down:
     plugin: ''
     function: ''
 
-  16: # LT
+  left_trigger:
     plugin: ''
     function: ''
 
-  17: # Right joystick left
+  right_stick_left:
     plugin: ''
     function: ''
 
-  18: # Right joystick right
+  right_stick_right:
     plugin: ''
     function: ''
 
-  19: # Right joystick up
+  right_stick_up:
     plugin: ''
     function: ''
 
-  20: # Right joystick down
+  right_stick_down:
     plugin: ''
     function: ''
 
-  21: # RT
+  right_trigger:
     plugin: ''
     function: ''
 
-  22: # Cross left
+  cross_left:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: arm_group/back
 
-  23: # Cross right
+  cross_right:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: arm_group/front
 
-  24: # Cross up
+  cross_up:
     plugin: ''
     function: ''
 
-  25: # Cross down
+  cross_down:
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: arm_group/folded

--- a/hector_gamepad_manager/test/config/manipulation.yaml
+++ b/hector_gamepad_manager/test/config/manipulation.yaml
@@ -76,59 +76,63 @@ buttons:
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: single_joint_mode
 
+  11: # Button Share (only on newer Xbox controllers)
+    plugin: ''
+    function: ''
+
   # -------------------- All the axes can also be used as buttons if specified here --------------------
-  11: # Left joystick left
+  12: # Left joystick left
     plugin: ''
     function: ''
 
-  12: # Left joystick right
+  13: # Left joystick right
     plugin: ''
     function: ''
 
-  13: # Left joystick up
+  14: # Left joystick up
     plugin: ''
     function: ''
 
-  14: # Left joystick down
+  15: # Left joystick down
     plugin: ''
     function: ''
 
-  15: # LT
+  16: # LT
     plugin: ''
     function: ''
 
-  16: # Right joystick left
+  17: # Right joystick left
     plugin: ''
     function: ''
 
-  17: # Right joystick right
+  18: # Right joystick right
     plugin: ''
     function: ''
 
-  18: # Right joystick up
+  19: # Right joystick up
     plugin: ''
     function: ''
 
-  19: # Right joystick down
+  20: # Right joystick down
     plugin: ''
     function: ''
 
-  20: # RT
+  21: # RT
     plugin: ''
     function: ''
 
-  21: # Cross left
+  22: # Cross left
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: arm_group/back
 
-  22: # Cross right
+  23: # Cross right
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: arm_group/front
 
-  23: # Cross up
+  24: # Cross up
     plugin: ''
     function: ''
 
-  24: # Cross down
+  25: # Cross down
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: arm_group/folded

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-constexpr int MAX_BUTTONS = 25;
+constexpr int MAX_BUTTONS = 26;
 constexpr int MAX_AXES = 8;
 
 class HectorGamepadManagerTest : public ::testing::Test
@@ -99,21 +99,14 @@ protected:
     EXPECT_CALL( *pub_nullspace_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
     EXPECT_CALL( *pub_joint_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
 
-    button_map_ = { { "a", 0 },
-                    { "b", 1 },
-                    { "x", 2 },
-                    { "y", 3 },
-                    { "lb", 4 },
-                    { "rb", 5 },
-                    { "back", 6 },
-                    { "start", 7 },
-                    { "power", 8 },
-                    { "left_joy", 9 },
-                    { "right_joy", 10 },
-                    { "cross_left", 21 },
-                    { "cross_right", 22 },
-                    { "cross_up", 23 },
-                    { "cross_down", 24 } };
+    button_map_ = { { "a", 0 },           { "b", 1 },
+                    { "x", 2 },           { "y", 3 },
+                    { "lb", 4 },          { "rb", 5 },
+                    { "back", 6 },        { "start", 7 },
+                    { "power", 8 },       { "left_joy", 9 },
+                    { "right_joy", 10 },  { "share", 11 },
+                    { "cross_left", 22 }, { "cross_right", 23 },
+                    { "cross_up", 24 },   { "cross_down", 25 } };
     axis_map_ = { { "left_stick_left_right", 0 },  { "left_stick_up_down", 1 },  { "lt", 2 },
                   { "right_stick_left_right", 3 }, { "right_stick_up_down", 4 }, { "rt", 5 },
                   { "cross_left_right", 6 },       { "cross_up_down", 7 } };
@@ -181,7 +174,7 @@ protected:
 
   void enableInvertSteering()
   {
-    setButton( "power", 1, true );
+    setButton( "share", 1, true );
     sendJoy();
     resetJoy();
   }
@@ -303,6 +296,34 @@ TEST_F( HectorGamepadManagerTest, CmdVelInvertedSteering )
 
   setAxis( "left_stick_left_right", 0.5f, true );
   setAxis( "left_stick_up_down", 0.5f );
+  sendJoy();
+}
+
+// Verifies invert_steering is toggleable from both the Guide button (pads without a Share
+// button) and the Share button, acting on the same blackboard flag.
+TEST_F( HectorGamepadManagerTest, InvertSteeringTogglesFromGuideAndShareButton )
+{
+  switchToConfig( "driving" );
+
+  // Toggle on via Guide (button 8) -> inverted
+  setButton( "power", 1, true );
+  sendJoy();
+  EXPECT_CALL( *pub_cmd_vel_, publish( ::testing::_ ) )
+      .WillOnce( []( const geometry_msgs::msg::TwistStamped &msg ) {
+        EXPECT_LT( msg.twist.linear.x, 0.0 );
+      } );
+  setAxis( "left_stick_up_down", 0.5f, true );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_cmd_vel_.get() );
+
+  // Toggle off via Share (button 11) -> back to normal
+  setButton( "share", 1, true );
+  sendJoy();
+  EXPECT_CALL( *pub_cmd_vel_, publish( ::testing::_ ) )
+      .WillOnce( []( const geometry_msgs::msg::TwistStamped &msg ) {
+        EXPECT_GT( msg.twist.linear.x, 0.0 );
+      } );
+  setAxis( "left_stick_up_down", 0.5f, true );
   sendJoy();
 }
 

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -27,7 +27,8 @@
 #include <string>
 #include <vector>
 
-constexpr int MAX_BUTTONS = 26;
+constexpr int MAX_BUTTONS =
+    12; // physical buttons on the wire; axis-derived buttons are synthesized internally
 constexpr int MAX_AXES = 8;
 
 class HectorGamepadManagerTest : public ::testing::Test
@@ -99,14 +100,9 @@ protected:
     EXPECT_CALL( *pub_nullspace_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
     EXPECT_CALL( *pub_joint_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
 
-    button_map_ = { { "a", 0 },           { "b", 1 },
-                    { "x", 2 },           { "y", 3 },
-                    { "lb", 4 },          { "rb", 5 },
-                    { "back", 6 },        { "start", 7 },
-                    { "power", 8 },       { "left_joy", 9 },
-                    { "right_joy", 10 },  { "share", 11 },
-                    { "cross_left", 22 }, { "cross_right", 23 },
-                    { "cross_up", 24 },   { "cross_down", 25 } };
+    button_map_ = { { "a", 0 },     { "b", 1 },        { "x", 2 },          { "y", 3 },
+                    { "lb", 4 },    { "rb", 5 },       { "back", 6 },       { "start", 7 },
+                    { "power", 8 }, { "left_joy", 9 }, { "right_joy", 10 }, { "share", 11 } };
     axis_map_ = { { "left_stick_left_right", 0 },  { "left_stick_up_down", 1 },  { "lt", 2 },
                   { "right_stick_left_right", 3 }, { "right_stick_up_down", 4 }, { "rt", 5 },
                   { "cross_left_right", 6 },       { "cross_up_down", 7 } };

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -21,7 +21,8 @@ using ::testing::AnyNumber;
 using ::testing::Field;
 using ::testing::HasSubstr;
 
-constexpr int MAX_BUTTONS = 26;
+constexpr int MAX_BUTTONS =
+    12; // physical buttons on the wire; axis-derived buttons are synthesized internally
 constexpr int MAX_AXES = 8;
 
 class HectorGamepadManagerDoublePressTest : public ::testing::Test

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_double_press.cpp
@@ -21,7 +21,7 @@ using ::testing::AnyNumber;
 using ::testing::Field;
 using ::testing::HasSubstr;
 
-constexpr int MAX_BUTTONS = 25;
+constexpr int MAX_BUTTONS = 26;
 constexpr int MAX_AXES = 8;
 
 class HectorGamepadManagerDoublePressTest : public ::testing::Test

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
@@ -1,9 +1,11 @@
 #include <gmock/gmock.h>
 #include <rclcpp/rclcpp.hpp>
+#include <rtest/create_timer_mock.hpp>
 #include <rtest/publisher_mock.hpp>
 #include <rtest/subscription_mock.hpp>
 
 #include <sensor_msgs/msg/joy.hpp>
+#include <sensor_msgs/msg/joy_feedback.hpp>
 #include <std_msgs/msg/string.hpp>
 
 #include <hector_gamepad_manager/hector_gamepad_manager.hpp>
@@ -31,6 +33,7 @@ protected:
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_hold_;
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_release_;
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_probe_axis_;
+  std::shared_ptr<rtest::PublisherMock<sensor_msgs::msg::JoyFeedback>> pub_feedback_;
 
   sensor_msgs::msg::Joy joy_msg_;
   std::map<std::string, int> button_map_;
@@ -62,8 +65,11 @@ protected:
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/release" );
     pub_probe_axis_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/test_probe/axis" );
+    pub_feedback_ =
+        rtest::findPublisher<sensor_msgs::msg::JoyFeedback>( node_, "/athena/joy_feedback" );
 
     ASSERT_TRUE( sub_joy_ );
+    ASSERT_TRUE( pub_feedback_ );
     ASSERT_TRUE( pub_config_ );
     ASSERT_TRUE( pub_probe_press_ );
     ASSERT_TRUE( pub_probe_hold_ );
@@ -75,6 +81,7 @@ protected:
     EXPECT_CALL( *pub_probe_hold_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
     EXPECT_CALL( *pub_probe_release_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
     EXPECT_CALL( *pub_probe_axis_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
+    EXPECT_CALL( *pub_feedback_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
 
     button_map_ = { { "a", 0 }, { "back", 6 }, { "start", 7 }, { "share", 11 } };
     axis_map_ = { { "left_stick_left_right", 0 } };
@@ -107,6 +114,14 @@ protected:
   }
 
   void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
+
+  // Fire the FeedbackManager's periodic publish timer once.
+  void fireFeedbackTimer()
+  {
+    for ( auto &timer : rtest::findTimers( node_ ) ) {
+      timer->execute_callback( std::make_shared<int>( 0 ) );
+    }
+  }
 };
 
 namespace
@@ -224,6 +239,49 @@ TEST_F( HectorGamepadManagerInternalTest, ShortJoyMessageTreatsMissingEntriesAsN
   joy_msg_.buttons.resize( 11 );
   joy_msg_.axes.resize( 2 );
   sendJoy();
+}
+
+// With config_switch_vibration_enabled: false, a config switch must not publish any rumble.
+TEST( HectorGamepadManagerRumble, DisabledViaParameter )
+{
+  auto node = makeNodeWithParams( "gamepad_manager_no_rumble_test",
+                                  "manager_internal_no_rumble_params.yaml" );
+  auto manager = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node );
+  auto sub_joy = rtest::findSubscription<sensor_msgs::msg::Joy>( node, "/athena/joy" );
+  auto pub_feedback =
+      rtest::findPublisher<sensor_msgs::msg::JoyFeedback>( node, "/athena/joy_feedback" );
+  ASSERT_TRUE( sub_joy );
+  ASSERT_TRUE( pub_feedback );
+
+  EXPECT_CALL( *pub_feedback, publish( ::testing::_ ) ).Times( 0 );
+  sensor_msgs::msg::Joy joy_msg;
+  joy_msg.axes = std::vector<float>( MAX_AXES, 0.0f );
+  joy_msg.axes[2] = 1.0f;
+  joy_msg.axes[5] = 1.0f;
+  joy_msg.buttons = std::vector<int>( MAX_BUTTONS, 0 );
+  joy_msg.buttons[6] = 1; // Back: switch to manager_internal_alt
+  sub_joy->handle_message( joy_msg );
+  for ( auto &timer : rtest::findTimers( node ) ) {
+    timer->execute_callback( std::make_shared<int>( 0 ) );
+  }
+}
+
+// A config switch fires a short one-shot rumble so the operator feels the mode change.
+// The initial config activation at startup must not rumble.
+TEST_F( HectorGamepadManagerInternalTest, ConfigSwitchTriggersRumble )
+{
+  // Startup (default config already active): feedback stays idle, nothing is published.
+  EXPECT_CALL( *pub_feedback_, publish( ::testing::_ ) ).Times( 0 );
+  fireFeedbackTimer();
+  ::testing::Mock::VerifyAndClearExpectations( pub_feedback_.get() );
+
+  // Switching to another config publishes a rumble with non-zero intensity.
+  EXPECT_CALL( *pub_feedback_, publish( ::testing::Field( &sensor_msgs::msg::JoyFeedback::intensity,
+                                                          ::testing::Gt( 0.0f ) ) ) )
+      .Times( 1 );
+  setButton( "back", 1, true ); // switch to manager_internal_alt
+  sendJoy();
+  fireFeedbackTimer();
 }
 
 TEST_F( HectorGamepadManagerInternalTest, ConfigSwitchBlocksOtherInputs )

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
@@ -14,7 +14,8 @@
 #include <string>
 #include <vector>
 
-constexpr int MAX_BUTTONS = 26;
+constexpr int MAX_BUTTONS =
+    12; // physical buttons on the wire; axis-derived buttons are synthesized internally
 constexpr int MAX_AXES = 8;
 
 class HectorGamepadManagerInternalTest : public ::testing::Test
@@ -108,6 +109,36 @@ protected:
   void sendJoy() { sub_joy_->handle_message( joy_msg_ ); }
 };
 
+namespace
+{
+std::shared_ptr<rclcpp::Node> makeNodeWithParams( const std::string &node_name,
+                                                  const std::string &params_filename )
+{
+  const auto params = std::filesystem::path( __FILE__ ).parent_path() / "config" / params_filename;
+  rclcpp::NodeOptions opts;
+  opts.arguments( { "--ros-args", "--params-file", params.string() } );
+  return std::make_shared<rclcpp::Node>( node_name, "athena", opts );
+}
+} // namespace
+
+// Physical button ids inside the virtual button range (>= 32) would collide with the axis-derived
+// buttons. Such entries must be skipped with a warning while the rest of the config still loads.
+TEST( HectorGamepadManagerConfigValidation, SkipsButtonIdsOverlappingVirtualRange )
+{
+  auto node = makeNodeWithParams( "gamepad_manager_overlapping_ids_test",
+                                  "manager_internal_overlapping_ids_params.yaml" );
+  auto manager = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node );
+  EXPECT_TRUE( rtest::findSubscription<sensor_msgs::msg::Joy>( node, "/athena/joy" ) );
+}
+
+TEST( HectorGamepadManagerConfigValidation, RejectsUnknownAxisButtonNames )
+{
+  auto node = makeNodeWithParams( "gamepad_manager_bad_axis_name_test",
+                                  "manager_internal_bad_axis_name_params.yaml" );
+  auto manager = std::make_shared<hector_gamepad_manager::HectorGamepadManager>( node );
+  EXPECT_FALSE( rtest::findSubscription<sensor_msgs::msg::Joy>( node, "/athena/joy" ) );
+}
+
 TEST_F( HectorGamepadManagerInternalTest, ButtonHoldAndReleaseSequence )
 {
   EXPECT_CALL( *pub_probe_press_,
@@ -148,6 +179,28 @@ TEST_F( HectorGamepadManagerInternalTest, ShareButtonMapsToButton11 )
                                           ::testing::HasSubstr( "release:share" ) ) ) )
       .Times( 1 );
   setButton( "share", 0, true );
+  sendJoy();
+}
+
+// Gamepads with more physical buttons than the Xbox layout (e.g. rear paddles) map 1:1 without
+// any code changes; button 13 is mapped in manager_internal.yaml.
+TEST_F( HectorGamepadManagerInternalTest, ExtraPhysicalButtonDispatches )
+{
+  EXPECT_CALL( *pub_probe_press_,
+               publish( ::testing::Field( &std_msgs::msg::String::data,
+                                          ::testing::HasSubstr( "press:extra" ) ) ) )
+      .Times( 1 );
+  resetJoy();
+  joy_msg_.buttons.resize( 14, 0 );
+  joy_msg_.buttons[13] = 1;
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  EXPECT_CALL( *pub_probe_release_,
+               publish( ::testing::Field( &std_msgs::msg::String::data,
+                                          ::testing::HasSubstr( "release:extra" ) ) ) )
+      .Times( 1 );
+  joy_msg_.buttons[13] = 0;
   sendJoy();
 }
 

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_internal.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-constexpr int MAX_BUTTONS = 25;
+constexpr int MAX_BUTTONS = 26;
 constexpr int MAX_AXES = 8;
 
 class HectorGamepadManagerInternalTest : public ::testing::Test
@@ -75,7 +75,7 @@ protected:
     EXPECT_CALL( *pub_probe_release_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
     EXPECT_CALL( *pub_probe_axis_, publish( ::testing::_ ) ).Times( ::testing::AnyNumber() );
 
-    button_map_ = { { "a", 0 }, { "back", 6 }, { "start", 7 } };
+    button_map_ = { { "a", 0 }, { "back", 6 }, { "start", 7 }, { "share", 11 } };
     axis_map_ = { { "left_stick_left_right", 0 } };
 
     resetJoy();
@@ -130,6 +130,46 @@ TEST_F( HectorGamepadManagerInternalTest, ButtonHoldAndReleaseSequence )
                                           ::testing::HasSubstr( "release:probe" ) ) ) )
       .Times( 1 );
   setButton( "a", 0, true );
+  sendJoy();
+}
+
+TEST_F( HectorGamepadManagerInternalTest, ShareButtonMapsToButton11 )
+{
+  EXPECT_CALL( *pub_probe_press_,
+               publish( ::testing::Field( &std_msgs::msg::String::data,
+                                          ::testing::HasSubstr( "press:share" ) ) ) )
+      .Times( 1 );
+  setButton( "share", 1, true );
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  EXPECT_CALL( *pub_probe_release_,
+               publish( ::testing::Field( &std_msgs::msg::String::data,
+                                          ::testing::HasSubstr( "release:share" ) ) ) )
+      .Times( 1 );
+  setButton( "share", 0, true );
+  sendJoy();
+}
+
+// Gamepads without a Share button publish only 11 buttons (older pads even fewer axes).
+// Entries missing from the message must read as "never pressed" instead of crashing.
+TEST_F( HectorGamepadManagerInternalTest, ShortJoyMessageTreatsMissingEntriesAsNeutral )
+{
+  EXPECT_CALL( *pub_probe_press_, publish( ::testing::_ ) ).Times( 0 );
+  resetJoy();
+  joy_msg_.buttons.resize( 11 ); // no Share button
+  joy_msg_.axes.resize( 2 );     // sticks only, no triggers / cross
+  sendJoy();
+  ::testing::Mock::VerifyAndClearExpectations( pub_probe_press_.get() );
+
+  // Buttons that do exist in the short message still dispatch normally.
+  EXPECT_CALL( *pub_probe_press_,
+               publish( ::testing::Field( &std_msgs::msg::String::data,
+                                          ::testing::HasSubstr( "press:probe" ) ) ) )
+      .Times( 1 );
+  setButton( "a", 1, true );
+  joy_msg_.buttons.resize( 11 );
+  joy_msg_.axes.resize( 2 );
   sendJoy();
 }
 

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -18,7 +18,7 @@ using ::testing::AnyNumber;
 using ::testing::Field;
 using ::testing::HasSubstr;
 
-constexpr int MAX_BUTTONS = 25;
+constexpr int MAX_BUTTONS = 26;
 constexpr int MAX_AXES = 8;
 
 // Verifies malformed YAML entries are skipped with a warning rather than throwing or registering broken mappings.

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -18,7 +18,8 @@ using ::testing::AnyNumber;
 using ::testing::Field;
 using ::testing::HasSubstr;
 
-constexpr int MAX_BUTTONS = 26;
+constexpr int MAX_BUTTONS =
+    12; // physical buttons on the wire; axis-derived buttons are synthesized internally
 constexpr int MAX_AXES = 8;
 
 // Verifies malformed YAML entries are skipped with a warning rather than throwing or registering broken mappings.

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/feedback_manager.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/feedback_manager.hpp
@@ -90,6 +90,11 @@ public:
         continue;
       }
       intensity = std::max( intensity, pattern->getIntensityNow() );
+      // One-shot patterns turn themselves off once played through, so isActive() stays truthful
+      // and a later setPatternActive(true) restarts them instead of being a silent no-op.
+      if ( pattern->isFinished() ) {
+        pattern->setActive( false );
+      }
       ++it;
     }
     if ( intensity <= 0.0 && last_intensity_ > 0.0 ) {

--- a/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/vibration_pattern.hpp
+++ b/hector_gamepad_plugin_interface/include/hector_gamepad_plugin_interface/vibration_pattern.hpp
@@ -76,11 +76,13 @@ public:
   /**
    * @brief Enable or disable the pattern.
    *
+   * Re-activating a non-cycling pattern that has already played through restarts it.
+   *
    * @param active True to start/continue the pattern, false to stop it.
    */
   void setActive( const bool active )
   {
-    if ( active && !active_ ) {
+    if ( active && ( !active_ || isFinished() ) ) {
       reset();
     }
     active_ = active;
@@ -90,6 +92,18 @@ public:
    * @brief Check whether the pattern is currently active.
    */
   bool isActive() const { return active_; }
+
+  /**
+   * @brief Whether a non-cycling pattern has played through completely. Cycling patterns never
+   * finish.
+   */
+  bool isFinished() const
+  {
+    if ( !active_ || cycle_ || !node_ ) {
+      return false;
+    }
+    return ( node_->now() - start_time_ ).seconds() >= total_duration_sec_;
+  }
 
   /**
    * @brief Get the instantaneous intensity based on the current time.

--- a/hector_gamepad_plugin_interface/test/test_ensure_controllers_active.cpp
+++ b/hector_gamepad_plugin_interface/test/test_ensure_controllers_active.cpp
@@ -1,0 +1,191 @@
+// Tests for GamepadFunctionPlugin::ensureControllersActive: level-triggered controller
+// reactivation with a retry throttle. Runs against fake in-process controller_manager
+// services (no real controller_manager needed).
+#include <gtest/gtest.h>
+
+#include <controller_manager_msgs/srv/list_controllers.hpp>
+#include <controller_manager_msgs/srv/switch_controller.hpp>
+#include <hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using controller_manager_msgs::srv::ListControllers;
+using controller_manager_msgs::srv::SwitchController;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+// Minimal fake controller manager (all controllers claim the same command interface).
+class FakeControllerManager
+{
+public:
+  explicit FakeControllerManager( const rclcpp::Node::SharedPtr &node )
+  {
+    list_service_ = node->create_service<ListControllers>(
+        "controller_manager/list_controllers",
+        [this]( const std::shared_ptr<ListControllers::Request>,
+                const std::shared_ptr<ListControllers::Response> response ) {
+          list_request_count_++;
+          std::lock_guard<std::mutex> lock( mutex_ );
+          for ( const auto &[name, active] : controller_active_ ) {
+            controller_manager_msgs::msg::ControllerState state;
+            state.name = name;
+            state.state = active ? "active" : "inactive";
+            state.required_command_interfaces = { "joint1/position" };
+            if ( active )
+              state.claimed_interfaces = { "joint1/position" };
+            response->controller.push_back( state );
+          }
+        } );
+    switch_service_ = node->create_service<SwitchController>(
+        "controller_manager/switch_controller",
+        [this]( const std::shared_ptr<SwitchController::Request> request,
+                const std::shared_ptr<SwitchController::Response> response ) {
+          std::lock_guard<std::mutex> lock( mutex_ );
+          for ( const auto &name : request->deactivate_controllers )
+            controller_active_[name] = false;
+          for ( const auto &name : request->activate_controllers ) {
+            controller_active_[name] = true;
+            activation_request_count_++;
+          }
+          response->ok = true;
+        } );
+  }
+
+  void setController( const std::string &name, const bool active )
+  {
+    std::lock_guard<std::mutex> lock( mutex_ );
+    controller_active_[name] = active;
+  }
+
+  int activationRequestCount() const { return activation_request_count_.load(); }
+  int listRequestCount() const { return list_request_count_.load(); }
+
+private:
+  std::mutex mutex_;
+  std::map<std::string, bool> controller_active_;
+  std::atomic_int activation_request_count_{ 0 };
+  std::atomic_int list_request_count_{ 0 };
+  rclcpp::Service<ListControllers>::SharedPtr list_service_;
+  rclcpp::Service<SwitchController>::SharedPtr switch_service_;
+};
+
+// Concrete plugin exposing the protected helper under test.
+class TestPlugin : public hector_gamepad_plugin_interface::GamepadFunctionPlugin
+{
+public:
+  using GamepadFunctionPlugin::ensureControllersActive;
+  void update() override { }
+  void activate() override { active_ = true; }
+  void deactivate() override { active_ = false; }
+
+protected:
+  void initialize( const rclcpp::Node::SharedPtr & ) override { }
+};
+
+class EnsureControllersActiveTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if ( !rclcpp::ok() )
+      rclcpp::init( 0, nullptr );
+    node_ = std::make_shared<rclcpp::Node>( "ensure_controllers_active_test" );
+    executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node( node_ );
+    spin_thread_ = std::thread( [this]() { executor_->spin(); } );
+
+    fake_cm_ = std::make_unique<FakeControllerManager>( node_ );
+    orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>( node_ );
+    plugin_ = std::make_shared<TestPlugin>();
+    plugin_->initializePlugin(
+        node_, "test::TestPlugin", std::make_shared<hector_gamepad_plugin_interface::Blackboard>(),
+        std::make_shared<hector_gamepad_plugin_interface::FeedbackManager>(), orchestrator_ );
+
+    const auto probe =
+        node_->create_client<ListControllers>( "controller_manager/list_controllers" );
+    ASSERT_TRUE( probe->wait_for_service( 5s ) );
+  }
+
+  void TearDown() override
+  {
+    executor_->cancel();
+    spin_thread_.join();
+  }
+
+  // Wait until the fake received `expected` activation requests (or time out).
+  bool waitForActivations( const int expected, const std::chrono::seconds timeout = 5s ) const
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while ( fake_cm_->activationRequestCount() < expected &&
+            std::chrono::steady_clock::now() < deadline ) {
+      std::this_thread::sleep_for( 10ms );
+    }
+    return fake_cm_->activationRequestCount() >= expected;
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::unique_ptr<FakeControllerManager> fake_cm_;
+  std::shared_ptr<controller_orchestrator::ControllerOrchestrator> orchestrator_;
+  std::shared_ptr<TestPlugin> plugin_;
+};
+
+} // namespace
+
+TEST_F( EnsureControllersActiveTest, EdgeTriggerActivatesImmediately )
+{
+  fake_cm_->setController( "ctrl", false );
+
+  plugin_->ensureControllersActive( { "ctrl" }, /*edge_trigger=*/true );
+
+  EXPECT_TRUE( waitForActivations( 1 ) );
+  EXPECT_EQ( fake_cm_->activationRequestCount(), 1 );
+}
+
+TEST_F( EnsureControllersActiveTest, LevelTriggerRetriesThrottledWhileInactive )
+{
+  fake_cm_->setController( "ctrl", false );
+
+  // Simulates the plugin update loop running at joystick rate while the stick is deflected:
+  // many calls without an edge must collapse into a single activation attempt.
+  for ( int i = 0; i < 25; i++ ) {
+    plugin_->ensureControllersActive( { "ctrl" }, /*edge_trigger=*/false );
+    std::this_thread::sleep_for( 2ms );
+  }
+  ASSERT_TRUE( waitForActivations( 1 ) );
+  std::this_thread::sleep_for( 200ms ); // grace period: no further attempts may sneak in
+  EXPECT_EQ( fake_cm_->activationRequestCount(), 1 );
+
+  // The switch already activated the controller in the fake, but the plugin's cached state is
+  // only refreshed by the next smart switch (there is no activity topic here). After the retry
+  // period, the stale-inactive cache must trigger exactly one more (no-op) switch...
+  std::this_thread::sleep_for( 1100ms );
+  const int list_requests_before = fake_cm_->listRequestCount();
+  plugin_->ensureControllersActive( { "ctrl" }, /*edge_trigger=*/false );
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while ( fake_cm_->listRequestCount() < list_requests_before + 1 &&
+          std::chrono::steady_clock::now() < deadline ) {
+    std::this_thread::sleep_for( 10ms );
+  }
+  EXPECT_EQ( fake_cm_->listRequestCount(), list_requests_before + 1 );
+  EXPECT_EQ( fake_cm_->activationRequestCount(), 1 ); // analysis found nothing to do
+
+  // ...and once the cache knows the controller is active, further calls do nothing at all.
+  std::this_thread::sleep_for( 1100ms );
+  const int list_requests_settled = fake_cm_->listRequestCount();
+  plugin_->ensureControllersActive( { "ctrl" }, /*edge_trigger=*/false );
+  std::this_thread::sleep_for( 500ms );
+  EXPECT_EQ( fake_cm_->listRequestCount(), list_requests_settled );
+  EXPECT_EQ( fake_cm_->activationRequestCount(), 1 );
+}

--- a/hector_gamepad_plugin_interface/test/test_feedback_manager.cpp
+++ b/hector_gamepad_plugin_interface/test/test_feedback_manager.cpp
@@ -60,6 +60,39 @@ TEST( FeedbackManager, EmitsSingleZeroAfterStopping )
   EXPECT_DOUBLE_EQ( manager.getVibrationIntensity(), -1.0 );
 }
 
+// A finished one-shot pattern turns itself off and can be retriggered with a later
+// setPatternActive(true). Previously the pattern stayed "active" forever after the first
+// playthrough, so every later activation was a silent no-op.
+TEST( FeedbackManager, OneShotPatternCanBeRetriggered )
+{
+  auto node = makeNode( "feedback_retrigger" );
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.03 };
+  defaults.off_durations_sec = { 0.0 };
+  defaults.intensity = 0.4;
+  defaults.cycle = false;
+
+  FeedbackManager manager;
+  manager.initialize( node );
+  manager.createVibrationPattern( "pattern", defaults );
+
+  manager.setPatternActive( "pattern", true );
+  EXPECT_TRUE( waitForCondition( [&]() { return manager.getVibrationIntensity() > 0.0; },
+                                 std::chrono::milliseconds( 80 ) ) );
+  // Auto-off runs inside getVibrationIntensity, mirroring the periodic publish tick.
+  EXPECT_TRUE( waitForCondition(
+      [&]() {
+        manager.getVibrationIntensity();
+        return !manager.isActive( "pattern" );
+      },
+      std::chrono::milliseconds( 120 ) ) );
+
+  // Second trigger must play the pattern again.
+  manager.setPatternActive( "pattern", true );
+  EXPECT_TRUE( waitForCondition( [&]() { return manager.getVibrationIntensity() > 0.0; },
+                                 std::chrono::milliseconds( 80 ) ) );
+}
+
 TEST( FeedbackManager, InactivePatternsReturnIdle )
 {
   auto node = makeNode( "feedback_inactive" );

--- a/hector_gamepad_plugin_interface/test/test_vibration_pattern.cpp
+++ b/hector_gamepad_plugin_interface/test/test_vibration_pattern.cpp
@@ -112,6 +112,30 @@ TEST( VibrationPattern, ReactivatingResetsTiming )
                                  std::chrono::milliseconds( 80 ) ) );
 }
 
+// setActive(true) on a finished one-shot pattern must restart it even without an intermediate
+// setActive(false) — this is how plugins retrigger notification buzzes.
+TEST( VibrationPattern, ReactivatingFinishedPatternRestartsIt )
+{
+  auto node = makeNode( "vibration_retrigger" );
+  VibrationPatternDefaults defaults;
+  defaults.on_durations_sec = { 0.03 };
+  defaults.off_durations_sec = { 0.0 };
+  defaults.intensity = 0.9;
+  defaults.cycle = false;
+
+  VibrationPattern pattern;
+  pattern.configure( node, "pattern.retrigger", defaults );
+  pattern.setActive( true );
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.isFinished(); },
+                                 std::chrono::milliseconds( 120 ) ) );
+
+  pattern.setActive( true ); // no setActive(false) in between
+
+  EXPECT_TRUE( waitForCondition( [&]() { return pattern.getIntensityNow() > 0.1; },
+                                 std::chrono::milliseconds( 80 ) ) );
+}
+
 TEST( VibrationPattern, RejectsInvalidParameterUpdates )
 {
   auto node = makeNode( "vibration_params" );

--- a/hector_gamepad_testing_tools/hector_gamepad_testing_tools/fake_joy_publisher.py
+++ b/hector_gamepad_testing_tools/hector_gamepad_testing_tools/fake_joy_publisher.py
@@ -38,10 +38,30 @@ class JoyLayout:
         neutrals = tuple(1.0 if i in (2, 5) else 0.0 for i in range(axis_count))
         return cls(
             axis_count=axis_count,
-            button_count=25,
+            button_count=12,  # physical buttons on the wire; virtual buttons are axis-derived
             neutrals=neutrals,
             trigger_axes=frozenset({2, 5}),
         )
+
+
+# Config "axis_buttons" name -> (axis index, logical deflection). Pressing such a virtual button
+# means deflecting the axis past the manager's press threshold; there is no wire button for it.
+AXIS_BUTTON_TO_AXIS: Dict[str, Tuple[int, float]] = {
+    "left_stick_left": (0, 1.0),
+    "left_stick_right": (0, -1.0),
+    "left_stick_up": (1, 1.0),
+    "left_stick_down": (1, -1.0),
+    "left_trigger": (2, 1.0),
+    "right_stick_left": (3, 1.0),
+    "right_stick_right": (3, -1.0),
+    "right_stick_up": (4, 1.0),
+    "right_stick_down": (4, -1.0),
+    "right_trigger": (5, 1.0),
+    "cross_left": (6, 1.0),
+    "cross_right": (6, -1.0),
+    "cross_up": (7, 1.0),
+    "cross_down": (7, -1.0),
+}
 
 
 @dataclass(frozen=True)
@@ -61,6 +81,8 @@ class Mode:
     name: str
     button_map: Dict[Key, int]
     axis_map: Dict[Key, int]
+    # virtual (axis-derived) buttons: Key -> axis_buttons name (see AXIS_BUTTON_TO_AXIS)
+    virtual_button_map: Dict[Key, str]
 
 
 def _pkg_config_path(pkg: str, name: str) -> str:
@@ -161,7 +183,7 @@ def _keys_in_mode_axis(keys: Set["Key"], mode: "Mode") -> Set["Key"]:
 
 
 def _keys_in_mode_button(keys: Set["Key"], mode: "Mode") -> Set["Key"]:
-    return {k for k in keys if k in mode.button_map}
+    return {k for k in keys if k in mode.button_map or k in mode.virtual_button_map}
 
 
 class FakeJoyPublisher(Node):
@@ -379,7 +401,9 @@ class FakeJoyPublisher(Node):
             for key in mode.axis_map.keys():
                 s = _safe_func_name(key.function)
                 axis_index.setdefault(s, set()).add(key)
-            for key in mode.button_map.keys():
+            for key in list(mode.button_map.keys()) + list(
+                mode.virtual_button_map.keys()
+            ):
                 s = _safe_func_name(key.function)
                 button_index.setdefault(s, set()).add(key)
         self._axis_name_to_keys = axis_index
@@ -505,26 +529,28 @@ class FakeJoyPublisher(Node):
         buttons = [0] * self.layout.button_count
         mode = self._modes[self._active_mode]
 
-        # Apply held buttons
-        for key in list(self._held_buttons):
+        def apply_button(key: Key, action: str) -> None:
             if key in mode.button_map:
                 buttons[mode.button_map[key]] = 1
+            elif key in mode.virtual_button_map:
+                # virtual button: deflect the corresponding axis past the press threshold
+                idx, logical = AXIS_BUTTON_TO_AXIS[mode.virtual_button_map[key]]
+                axes[idx] = self.layout.logical_to_raw(idx, logical)
             else:
                 raise RuntimeError(
-                    f"Held button {key} not available in active mode '{self._active_mode}'"
+                    f"{action} button {key} not available in active mode '{self._active_mode}'"
                 )
+
+        # Apply held buttons
+        for key in list(self._held_buttons):
+            apply_button(key, "Held")
 
         # Apply one-shot presses
         for key in list(self._pending_one_shot_keys):
-            if key in mode.button_map:
-                self.get_logger().info(
-                    f"Pressing button {key} in mode '{self._active_mode} [button index: {mode.button_map[key]} vs. button len {len(mode.button_map)} ]"
-                )
-                buttons[mode.button_map[key]] = 1
-            else:
-                raise RuntimeError(
-                    f"Pressed button {key} not available in active mode '{self._active_mode}'"
-                )
+            self.get_logger().info(
+                f"Pressing button {key} in mode '{self._active_mode}'"
+            )
+            apply_button(key, "Pressed")
         self._pending_one_shot_keys.clear()
 
         # Apply axes
@@ -549,6 +575,7 @@ class FakeJoyPublisher(Node):
     def _parse_mode(self, name: str, cfg: dict, reserved_buttons: Set[int]) -> Mode:
         buttons = {}
         axes = {}
+        virtual_buttons = {}
         for k, v in (cfg.get("buttons") or {}).items():
             idx = int(k)
             if idx in reserved_buttons:
@@ -557,6 +584,13 @@ class FakeJoyPublisher(Node):
             func = (v or {}).get("function", "") or ""
             if plugin and func:
                 buttons[Key(plugin, func)] = idx
+        for k, v in (cfg.get("axis_buttons") or {}).items():
+            if k not in AXIS_BUTTON_TO_AXIS:
+                raise ValueError(f"Unknown axis button '{k}' in config '{name}'")
+            plugin = (v or {}).get("plugin", "") or ""
+            func = (v or {}).get("function", "") or ""
+            if plugin and func:
+                virtual_buttons[Key(plugin, func)] = k
         for k, v in (cfg.get("axes") or {}).items():
             idx = int(k)
             plugin = (v or {}).get("plugin", "") or ""
@@ -564,20 +598,32 @@ class FakeJoyPublisher(Node):
             if plugin and func:
                 axes[Key(plugin, func)] = idx
         self.get_logger().info(
-            f"Loaded mode '{name}' with {len(buttons)} buttons and {len(axes)} axes"
-            f"\nButtons:{yaml.dump(buttons)}, \nAxes:{yaml.dump(axes)}"
+            f"Loaded mode '{name}' with {len(buttons)} buttons, "
+            f"{len(virtual_buttons)} virtual buttons and {len(axes)} axes"
+            f"\nButtons:{yaml.dump(buttons)}, \nVirtual buttons:{yaml.dump(virtual_buttons)}, "
+            f"\nAxes:{yaml.dump(axes)}"
         )
-        return Mode(name=name, button_map=buttons, axis_map=axes)
+        return Mode(
+            name=name,
+            button_map=buttons,
+            axis_map=axes,
+            virtual_button_map=virtual_buttons,
+        )
 
     def _find_mode_for_key(self, key: Key, active_mode: str) -> Optional[str]:
         # preferred: active mode first, then all modes
         if (
             key in self._modes[active_mode].button_map
+            or key in self._modes[active_mode].virtual_button_map
             or key in self._modes[active_mode].axis_map
         ):
             return active_mode
         for name, mode in self._modes.items():
-            if key in mode.button_map or key in mode.axis_map:
+            if (
+                key in mode.button_map
+                or key in mode.virtual_button_map
+                or key in mode.axis_map
+            ):
                 return name
         return None
 


### PR DESCRIPTION
### Motivation
The invert-steering toggle lived on the **Guide button (8)**, which is unreliable on real Xbox Series pads: pressing it can trigger a USB reset, so presses never arrive. The **Share button (joy index 11)** works reliably, but the manager had no room for it: joy buttons 0–10 were copied 1:1 and internal ids 11–24 were already taken by the synthesized axes-as-buttons (sticks/triggers/D-pad).

### Changes
- **Manager**: widen the internal button space to 26; map joy button 11 (Share) to   internal id 11 and shift the axes-as-buttons block to ids 12–25
- **Robustness**: `convertJoyToGamepadInputs` now reads buttons/axes bounds-checked,   pads that don't report a button (e.g. no Share) simply never press it, instead of indexing past the end of the message
- **Configs** (all renumbered for the shifted IDs): `invert_steering` is now mapped to **both** Share (11, for real Xbox pads) and Guide (8, kept as a fallback for controllers without a Share button). Both toggle the same blackboard flag, which is safe; each press just inverts it.