### PR TITLE
Add descriptions to configs and advertise the profiles with description so UI can show the mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,37 @@ Each configuration file maps **buttons/axes** to **plugin functions**.
 Functions can now include **parameters** via the `args` field. These parameters are stored in the shared **blackboard**
 and are uniquely namespaced, so you can reuse the same function in different or even within the same config.
 
+Each mapping may carry an optional `description`: a short human-readable label of what it does.
+Descriptions are published on the latched `joy_mapping` topic (a `GamepadMapping` message carrying the
+full mapping of every loaded config) so a user interface can show the current controls. An optional
+top-level `description` describes the config itself. Descriptions never affect behavior.
+
 #### Example: Driving Configuration (basic format)
 
 ```yaml
+description: "Drive the robot and control the flippers"   # optional, describes the config
+
 axes:
   0: # Left joystick left/right
     plugin: "hector_gamepad_manager_plugins::DrivePlugin"
     function: "steer"
+    description: "Steer"
 
   1: # Left joystick up/down
     plugin: "hector_gamepad_manager_plugins::DrivePlugin"
     function: "drive"
+    description: "Drive forward/backward"
 
 buttons:
   0: # Button A
     plugin: "hector_gamepad_manager_plugins::DrivePlugin"
     function: "fast"
+    description: "Drive fast (hold)"
 
   1: # Button B
     plugin: "hector_gamepad_manager_plugins::MoveitPlugin"
     function: "go_to_pose"
+    description: "Fold arm"
     args:
       group: "arm_group"
       pose: "folded"
@@ -119,8 +130,10 @@ buttons:
     plugin: "hector_gamepad_manager_plugins::FlipperPlugin"
     on_press:
       function: "flipper_back_up"
+      description: "Raise back flippers"     # optional, per event
     on_double_press:
       function: "flipper_back_upright"
+      description: "Back flippers to upright position"
     on_hold:                          # optional, defaults to on_press function
       function: "flipper_back_up"
     on_release:                       # optional, defaults to on_press function
@@ -128,6 +141,9 @@ buttons:
     args:                             # shared by all events on this button
       some_param: 1.0
 ```
+
+Each event may carry its own `description`, so a button with `on_press` and `on_double_press`
+shows two separate labels in the user interface.
 
 Available event types:
 - **`on_press`** *(required)*: Triggered on button press (single press). This is equivalent to the basic `function` field. It is also the fallback target for `on_hold`/`on_release` and the dispatch target on a single tap when `on_double_press` is configured, so a new-format mapping without `on_press` is rejected at load time.

--- a/hector_gamepad_manager/CMakeLists.txt
+++ b/hector_gamepad_manager/CMakeLists.txt
@@ -18,19 +18,20 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 set(DEPENDENCIES pluginlib rclcpp sensor_msgs yaml-cpp
-                 hector_gamepad_plugin_interface controller_orchestrator)
+                 hector_gamepad_plugin_interface controller_orchestrator
+                 hector_gamepad_manager_msgs)
 
 foreach(dependency IN LISTS DEPENDENCIES)
   find_package(${dependency} REQUIRED)
 endforeach()
 
-# Used only by the operator-station joy satellite node (standalone + component).
-find_package(hector_gamepad_manager_msgs REQUIRED)
 find_package(rclcpp_components REQUIRED)
 
-set(HEADERS include/hector_gamepad_manager/hector_gamepad_manager.hpp)
+set(HEADERS include/hector_gamepad_manager/hector_gamepad_manager.hpp
+            include/hector_gamepad_manager/gamepad_config.hpp
+            include/hector_gamepad_manager/gamepad_mapping_builder.hpp)
 
-set(SOURCES src/hector_gamepad_manager.cpp)
+set(SOURCES src/hector_gamepad_manager.cpp src/gamepad_mapping_builder.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 target_include_directories(
@@ -114,6 +115,14 @@ if(BUILD_TESTING)
       ENVIRONMENT
       "AMENT_PREFIX_PATH=${PLUGIN_TEST_PREFIX}:${CMAKE_INSTALL_PREFIX}:$ENV{AMENT_PREFIX_PATH}"
   )
+
+  # Builder unit test: pure message construction, no node or rtest needed.
+  ament_add_gmock(test_gamepad_mapping_builder test/main.cpp
+                  test/test_gamepad_mapping_builder.cpp)
+  target_include_directories(test_gamepad_mapping_builder
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  target_link_libraries(test_gamepad_mapping_builder ${PROJECT_NAME})
+  ament_target_dependencies(test_gamepad_mapping_builder ${DEPENDENCIES})
 
   # Satellite test: header-only node compiled directly against the rtest mocks
   # (no plugins).

--- a/hector_gamepad_manager/CMakeLists.txt
+++ b/hector_gamepad_manager/CMakeLists.txt
@@ -17,9 +17,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-set(DEPENDENCIES pluginlib rclcpp sensor_msgs yaml-cpp
-                 hector_gamepad_plugin_interface controller_orchestrator
-                 hector_gamepad_manager_msgs)
+set(DEPENDENCIES
+    pluginlib
+    rclcpp
+    sensor_msgs
+    yaml-cpp
+    hector_gamepad_plugin_interface
+    controller_orchestrator
+    hector_gamepad_manager_msgs)
 
 foreach(dependency IN LISTS DEPENDENCIES)
   find_package(${dependency} REQUIRED)
@@ -27,9 +32,10 @@ endforeach()
 
 find_package(rclcpp_components REQUIRED)
 
-set(HEADERS include/hector_gamepad_manager/hector_gamepad_manager.hpp
-            include/hector_gamepad_manager/gamepad_config.hpp
-            include/hector_gamepad_manager/gamepad_mapping_builder.hpp)
+set(HEADERS
+    include/hector_gamepad_manager/hector_gamepad_manager.hpp
+    include/hector_gamepad_manager/gamepad_config.hpp
+    include/hector_gamepad_manager/gamepad_mapping_builder.hpp)
 
 set(SOURCES src/hector_gamepad_manager.cpp src/gamepad_mapping_builder.cpp)
 

--- a/hector_gamepad_manager/config/athena.yaml
+++ b/hector_gamepad_manager/config/athena.yaml
@@ -30,10 +30,12 @@ buttons:
   6: # Button Back
     package: hector_gamepad_manager
     config: manipulation
+    description: Switch to manipulation mode
 
   7: # Button Start
     package: hector_gamepad_manager
     config: driving
+    description: Switch to driving mode
 
   8: # Button Guide (Manufacturer Button)
     package: ''

--- a/hector_gamepad_manager/config/driving.yaml
+++ b/hector_gamepad_manager/config/driving.yaml
@@ -1,27 +1,35 @@
+description: Drive the robot and control the flippers
+
 axes:
   0: # Left joystick left/right
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: steer
+    description: Steer
 
   1: # Left joystick up/down
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: drive
+    description: Drive forward/backward
 
   2: # LT
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
     function: flipper_back_down
+    description: Lower back flippers
 
   3: # Right joystick left/right
     plugin: hector_gamepad_manager_plugins::VirtualCameraPlugin
     function: camera_pan
+    description: Pan camera
 
   4: # Right joystick up/down
     plugin: hector_gamepad_manager_plugins::VirtualCameraPlugin
     function: camera_tilt
+    description: Tilt camera
 
   5: # RT
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
     function: flipper_front_down
+    description: Lower front flippers
 
   6: # Cross left/right
     plugin: ''
@@ -35,38 +43,48 @@ buttons:
   0: # Button A
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: slow
+    description: Drive slowly (hold)
 
   1: # Button B
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
     on_press:
       function: individual_front_flipper_control_mode
+      description: Control front flippers individually
     on_double_press:
       function: sync_front_flippers
+      description: Sync front flippers
 
   2: # Button X
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
     on_press:
       function: individual_back_flipper_control_mode
+      description: Control back flippers individually
     on_double_press:
       function: sync_back_flippers
+      description: Sync back flippers
 
   3: # Button Y
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: fast
+    description: Drive fast (hold)
 
   4: # Button LB
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
     on_press:
       function: flipper_back_up
+      description: Raise back flippers
     on_double_press:
       function: flipper_back_upright
+      description: Back flippers to upright position
 
   5: # Button RB
     plugin: hector_gamepad_manager_plugins::FlipperPlugin
     on_press:
       function: flipper_front_up
+      description: Raise front flippers
     on_double_press:
       function: flipper_front_upright
+      description: Front flippers to upright position
 
   6: # Button Back
     plugin: ''
@@ -79,6 +97,7 @@ buttons:
   8: # Button Guide (Manufacturer Button)
     plugin: hector_gamepad_manager_plugins::BlackboardPlugin
     function: toggle
+    description: Toggle inverted steering
     args:
       name: invert_steering
       ocs_topic: joy_teleop_direction
@@ -86,6 +105,7 @@ buttons:
   9: # Left joystick press
     plugin: hector_gamepad_manager_plugins::BlackboardPlugin
     function: toggle
+    description: Toggle software emergency stop
     args:
       name: software_e_stop
       initial: 'false'
@@ -95,6 +115,7 @@ buttons:
   10: # Right joystick press
     plugin: hector_gamepad_manager_plugins::VirtualCameraPlugin
     function: reset_camera
+    description: Reset camera view
 
   # -------------------- All the axes can also be used as buttons if specified here --------------------
   11: # Left joystick left
@@ -140,6 +161,7 @@ buttons:
   21: # Cross left
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Flippers to tub pose
     args:
       group: flipper_group
       pose: tub
@@ -147,6 +169,7 @@ buttons:
   22: # Cross right
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Flippers to compact pose
     args:
       group: flipper_group
       pose: compact
@@ -154,6 +177,7 @@ buttons:
   23: # Cross up
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Flippers to up pose
     args:
       group: flipper_group
       pose: up
@@ -161,6 +185,7 @@ buttons:
   24: # Cross down
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Flippers to flat pose
     args:
       group: flipper_group
       pose: flat

--- a/hector_gamepad_manager/config/driving_simple.yaml
+++ b/hector_gamepad_manager/config/driving_simple.yaml
@@ -1,11 +1,15 @@
+description: Simple driving controls
+
 axes:
   0: # Left joystick left/right
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: steer
+    description: Steer
 
   1: # Left joystick up/down
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: drive
+    description: Drive forward/backward
 
   2: # LT
     plugin: ''
@@ -35,6 +39,7 @@ buttons:
   0: # Button A
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: fast
+    description: Drive fast (hold)
 
   1: # Button B
     plugin: ''
@@ -43,6 +48,7 @@ buttons:
   2: # Button X
     plugin: hector_gamepad_manager_plugins::DrivePlugin
     function: slow
+    description: Drive slowly (hold)
 
   3: # Button Y
     plugin: ''
@@ -71,6 +77,7 @@ buttons:
   9: # Left joystick press
     plugin: hector_gamepad_manager_plugins::BatteryMonitorPlugin
     function: mute
+    description: Mute battery warnings
 
   10: # Right joystick press
     plugin: ''

--- a/hector_gamepad_manager/config/ec_scout.yaml
+++ b/hector_gamepad_manager/config/ec_scout.yaml
@@ -34,6 +34,7 @@ buttons:
   7: # Button Start
     package: hector_gamepad_manager
     config: driving_simple
+    description: Switch to driving mode
 
   8: # Button Guide (Manufacturer Button)
     package: ''

--- a/hector_gamepad_manager/config/ec_swift.yaml
+++ b/hector_gamepad_manager/config/ec_swift.yaml
@@ -34,6 +34,7 @@ buttons:
   7: # Button Start
     package: hector_gamepad_manager
     config: driving_simple
+    description: Switch to driving mode
 
   8: # Button Guide (Manufacturer Button)
     package: ''

--- a/hector_gamepad_manager/config/manipulation.yaml
+++ b/hector_gamepad_manager/config/manipulation.yaml
@@ -1,27 +1,35 @@
+description: Control the manipulator arm and gripper
+
 axes:
   0: # Left joystick left/right
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: move_left_right
+    description: Move end effector left/right
 
   1: # Left joystick up/down
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: move_up_down
+    description: Move end effector up/down
 
   2: # LT
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: move_backward
+    description: Move end effector backward
 
   3: # Right joystick left/right
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: rotate_yaw
+    description: Rotate end effector (yaw)
 
   4: # Right joystick up/down
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: rotate_pitch
+    description: Rotate end effector (pitch)
 
   5: # RT
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: move_forward
+    description: Move end effector forward
 
   6: # Cross right/left
     plugin: ''
@@ -35,26 +43,32 @@ buttons:
   0: # Button A
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: nullspace_mode
+    description: Nullspace motion mode (hold)
 
   1: # Button B
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: hold_mode
+    description: Hold current pose (hold)
 
   2: # Button X
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: gripper_close
+    description: Close gripper
 
   3: # Button Y
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: gripper_open
+    description: Open gripper
 
   4: # Button LB
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: rotate_roll_counter_clockwise
+    description: Roll end effector CCW
 
   5: # Button RB
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: rotate_roll_clockwise
+    description: Roll end effector CW
 
   6: # Button Back
     plugin: ''
@@ -67,6 +81,7 @@ buttons:
   8: # Button Guide (Manufacturer Button)
     plugin: hector_gamepad_manager_plugins::BlackboardPlugin
     function: toggle
+    description: Toggle inverted steering
     args:
       name: invert_steering
       ocs_topic: joy_teleop_direction
@@ -74,6 +89,7 @@ buttons:
   9: # Left joystick press
     plugin: hector_gamepad_manager_plugins::BlackboardPlugin
     function: toggle
+    description: Toggle software emergency stop
     args:
       name: software_e_stop
       initial: 'false'
@@ -82,6 +98,7 @@ buttons:
   10: # Right joystick press
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: single_joint_mode
+    description: Single joint control mode (hold)
 
   # -------------------- All the axes can also be used as buttons if specified here --------------------
   11: # Left joystick left
@@ -127,6 +144,7 @@ buttons:
   21: # Cross left
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Move arm to back pose
     args:
       group: arm_group
       pose: back
@@ -135,6 +153,7 @@ buttons:
   22: # Cross right
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Move arm to front pose
     args:
       group: arm_group
       pose: front
@@ -147,6 +166,7 @@ buttons:
   24: # Cross down
     plugin: hector_gamepad_manager_plugins::MoveitPlugin
     function: go_to_pose
+    description: Fold arm
     args:
       group: arm_group
       pose: folded

--- a/hector_gamepad_manager/config/manipulation.yaml
+++ b/hector_gamepad_manager/config/manipulation.yaml
@@ -48,7 +48,7 @@ buttons:
   1: # Button B
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin
     function: hold_mode
-    description: Hold current pose (hold)
+    description: Drive base holding current EEF pose (hold)
 
   2: # Button X
     plugin: hector_gamepad_manager_plugins::ManipulationPlugin

--- a/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_config.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_config.hpp
@@ -1,0 +1,59 @@
+#ifndef HECTOR_GAMEPAD_MANAGER_GAMEPAD_CONFIG_HPP
+#define HECTOR_GAMEPAD_MANAGER_GAMEPAD_CONFIG_HPP
+
+#include "hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace hector_gamepad_manager
+{
+using GamepadFunctionPlugin = hector_gamepad_plugin_interface::GamepadFunctionPlugin;
+
+// Total addressable buttons: indices 0-10 physical, 11-24 virtual (axis deflection past a deadzone).
+constexpr std::size_t kNumButtons = 25;
+
+// A single plugin function bound to one button event, with its human-readable description.
+struct ActionMapping {
+  std::string function;
+  std::string description;
+
+  bool empty() const { return function.empty(); }
+};
+
+// Mapping of an axis to a function of a plugin.
+struct FunctionMapping {
+  std::shared_ptr<GamepadFunctionPlugin> plugin;
+  std::string function_name;
+  std::string description;
+};
+
+// For double-press buttons the manager bypasses handleButton and dispatches handlePress /
+// handleHold / handleRelease directly, so plugins must not rely on button_states_ for them.
+struct ButtonFunctionMapping {
+  std::shared_ptr<GamepadFunctionPlugin> plugin;
+
+  ActionMapping on_press;        // called on initial press
+  ActionMapping on_double_press; // called on double press (empty = disabled)
+  ActionMapping on_hold;         // called while held (empty = uses on_press)
+  ActionMapping on_release;      // called on release (empty = uses on_press)
+
+  bool has_double_press() const { return !on_double_press.empty(); }
+};
+
+// A button that switches the active configuration.
+struct ConfigSwitch {
+  std::string config;
+  std::string description;
+};
+
+struct GamepadConfig {
+  std::string description; // optional top-level description of the config, from YAML; may be empty
+  std::unordered_map<int, ButtonFunctionMapping> button_mappings;
+  std::unordered_map<int, FunctionMapping> axis_mappings;
+};
+} // namespace hector_gamepad_manager
+
+#endif // HECTOR_GAMEPAD_MANAGER_GAMEPAD_CONFIG_HPP

--- a/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_mapping_builder.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_mapping_builder.hpp
@@ -13,9 +13,10 @@ namespace hector_gamepad_manager
 {
 // Build the static GamepadMapping message from the loaded configs.
 // Kept free of any ROS node so the message content can be unit-tested directly.
-hector_gamepad_manager_msgs::msg::GamepadMapping buildGamepadMappingMsg(
-    const std::map<std::string, GamepadConfig> &configs,
-    const std::array<ConfigSwitch, kNumButtons> &config_switches, const std::string &default_config );
+hector_gamepad_manager_msgs::msg::GamepadMapping
+buildGamepadMappingMsg( const std::map<std::string, GamepadConfig> &configs,
+                        const std::array<ConfigSwitch, kNumButtons> &config_switches,
+                        const std::string &default_config );
 } // namespace hector_gamepad_manager
 
 #endif // HECTOR_GAMEPAD_MANAGER_GAMEPAD_MAPPING_BUILDER_HPP

--- a/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_mapping_builder.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/gamepad_mapping_builder.hpp
@@ -1,0 +1,21 @@
+#ifndef HECTOR_GAMEPAD_MANAGER_GAMEPAD_MAPPING_BUILDER_HPP
+#define HECTOR_GAMEPAD_MANAGER_GAMEPAD_MAPPING_BUILDER_HPP
+
+#include "hector_gamepad_manager/gamepad_config.hpp"
+
+#include <hector_gamepad_manager_msgs/msg/gamepad_mapping.hpp>
+
+#include <array>
+#include <map>
+#include <string>
+
+namespace hector_gamepad_manager
+{
+// Build the static GamepadMapping message from the loaded configs.
+// Kept free of any ROS node so the message content can be unit-tested directly.
+hector_gamepad_manager_msgs::msg::GamepadMapping buildGamepadMappingMsg(
+    const std::map<std::string, GamepadConfig> &configs,
+    const std::array<ConfigSwitch, kNumButtons> &config_switches, const std::string &default_config );
+} // namespace hector_gamepad_manager
+
+#endif // HECTOR_GAMEPAD_MANAGER_GAMEPAD_MAPPING_BUILDER_HPP

--- a/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
+++ b/hector_gamepad_manager/include/hector_gamepad_manager/hector_gamepad_manager.hpp
@@ -1,10 +1,12 @@
 #ifndef HECTOR_GAMEPAD_MANAGER_HECTOR_GAMEPAD_MANAGER_HPP
 #define HECTOR_GAMEPAD_MANAGER_HECTOR_GAMEPAD_MANAGER_HPP
 
+#include "hector_gamepad_manager/gamepad_config.hpp"
 #include "hector_gamepad_plugin_interface/feedback_manager.hpp"
 #include "hector_gamepad_plugin_interface/gamepad_plugin_interface.hpp"
 
 #include <controller_orchestrator/controller_orchestrator.hpp>
+#include <hector_gamepad_manager_msgs/msg/gamepad_mapping.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
@@ -21,27 +23,6 @@ public:
   explicit HectorGamepadManager( const rclcpp::Node::SharedPtr &node );
 
 private:
-  // Struct to store the mapping of an axis to a function of a plugin
-  struct FunctionMapping {
-    // Name of the plugin
-    std::shared_ptr<GamepadFunctionPlugin> plugin;
-
-    // Name of the function
-    std::string function_name;
-  };
-
-  // For double-press buttons the manager bypasses handleButton and dispatches handlePress / handleHold / handleRelease directly, so plugins must not rely on button_states_ for them.
-  struct ButtonFunctionMapping {
-    std::shared_ptr<GamepadFunctionPlugin> plugin;
-
-    std::string on_press;        // function called on initial press
-    std::string on_double_press; // function called on double press (empty = disabled)
-    std::string on_hold;         // function called while held (empty = uses on_press)
-    std::string on_release;      // function called on release (empty = uses on_press)
-
-    bool has_double_press() const { return !on_double_press.empty(); }
-  };
-
   // Per-button state for double-press detection
   struct ButtonTracker {
     bool pressed = false;          // current physical state
@@ -55,12 +36,7 @@ private:
     // Vector of axes values
     std::array<float, 8> axes = std::array<float, 8>{ 0.0 };
 
-    std::array<bool, 25> buttons = std::array<bool, 25>{ false };
-  };
-
-  struct GamepadConfig {
-    std::unordered_map<int, ButtonFunctionMapping> button_mappings;
-    std::unordered_map<int, FunctionMapping> axis_mappings;
+    std::array<bool, kNumButtons> buttons = std::array<bool, kNumButtons>{ false };
   };
 
   rclcpp::Node::SharedPtr node_;
@@ -70,13 +46,16 @@ private:
   // Publish active configuration -> visualization in user interface
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr active_config_publisher_;
 
+  // Publish the full static button/axis mapping of all loaded configs, once at startup.
+  rclcpp::Publisher<hector_gamepad_manager_msgs::msg::GamepadMapping>::SharedPtr mapping_publisher_;
+
   // Class loader for the gamepad function plugins
   pluginlib::ClassLoader<GamepadFunctionPlugin> plugin_loader_;
 
   std::map<std::string, GamepadConfig> configs_;
 
-  // Maps buttons to config names
-  std::array<std::string, 25> config_switch_button_mapping_;
+  // Maps buttons to the config they switch to
+  std::array<ConfigSwitch, kNumButtons> config_switch_button_mapping_;
 
   // Name of the active configuration
   std::string active_config_;

--- a/hector_gamepad_manager/src/gamepad_mapping_builder.cpp
+++ b/hector_gamepad_manager/src/gamepad_mapping_builder.cpp
@@ -1,0 +1,81 @@
+#include "hector_gamepad_manager/gamepad_mapping_builder.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace hector_gamepad_manager
+{
+namespace
+{
+using hector_gamepad_manager_msgs::msg::GamepadAction;
+
+// Append an action to the list if it is configured (has a function).
+void addAction( std::vector<GamepadAction> &actions, uint8_t event, const ActionMapping &mapping )
+{
+  if ( mapping.empty() )
+    return;
+  GamepadAction action;
+  action.event = event;
+  action.function = mapping.function;
+  action.description = mapping.description;
+  actions.push_back( action );
+}
+
+std::string pluginId( const std::shared_ptr<GamepadFunctionPlugin> &plugin )
+{
+  return plugin ? plugin->getPluginId() : std::string();
+}
+} // namespace
+
+hector_gamepad_manager_msgs::msg::GamepadMapping buildGamepadMappingMsg(
+    const std::map<std::string, GamepadConfig> &configs,
+    const std::array<ConfigSwitch, kNumButtons> &config_switches, const std::string &default_config )
+{
+  hector_gamepad_manager_msgs::msg::GamepadMapping msg;
+  msg.default_config = default_config;
+
+  for ( const auto &[config_name, config] : configs ) {
+    hector_gamepad_manager_msgs::msg::GamepadConfigMapping config_msg;
+    config_msg.name = config_name;
+    config_msg.description = config.description;
+
+    for ( const auto &[index, mapping] : config.button_mappings ) {
+      hector_gamepad_manager_msgs::msg::GamepadButtonMapping button_msg;
+      button_msg.index = static_cast<uint8_t>( index );
+      button_msg.plugin = pluginId( mapping.plugin );
+      addAction( button_msg.actions, GamepadAction::EVENT_PRESS, mapping.on_press );
+      addAction( button_msg.actions, GamepadAction::EVENT_DOUBLE_PRESS, mapping.on_double_press );
+      addAction( button_msg.actions, GamepadAction::EVENT_HOLD, mapping.on_hold );
+      addAction( button_msg.actions, GamepadAction::EVENT_RELEASE, mapping.on_release );
+      config_msg.buttons.push_back( button_msg );
+    }
+    std::sort( config_msg.buttons.begin(), config_msg.buttons.end(),
+               []( const auto &a, const auto &b ) { return a.index < b.index; } );
+
+    for ( const auto &[index, mapping] : config.axis_mappings ) {
+      hector_gamepad_manager_msgs::msg::GamepadAxisMapping axis_msg;
+      axis_msg.index = static_cast<uint8_t>( index );
+      axis_msg.plugin = pluginId( mapping.plugin );
+      axis_msg.function = mapping.function_name;
+      axis_msg.description = mapping.description;
+      config_msg.axes.push_back( axis_msg );
+    }
+    std::sort( config_msg.axes.begin(), config_msg.axes.end(),
+               []( const auto &a, const auto &b ) { return a.index < b.index; } );
+
+    msg.configs.push_back( config_msg );
+  }
+
+  for ( size_t i = 0; i < config_switches.size(); ++i ) {
+    if ( config_switches[i].config.empty() )
+      continue;
+    hector_gamepad_manager_msgs::msg::GamepadConfigSwitch switch_msg;
+    switch_msg.index = static_cast<uint8_t>( i );
+    switch_msg.config = config_switches[i].config;
+    switch_msg.description = config_switches[i].description;
+    msg.config_switches.push_back( switch_msg );
+  }
+
+  return msg;
+}
+} // namespace hector_gamepad_manager

--- a/hector_gamepad_manager/src/gamepad_mapping_builder.cpp
+++ b/hector_gamepad_manager/src/gamepad_mapping_builder.cpp
@@ -9,7 +9,7 @@ namespace
 {
 using hector_gamepad_manager_msgs::msg::GamepadAction;
 
-// Append an action to the list if it is configured (has a function).
+// Append an action to the list if it is configured (has a non-empty mapping).
 void addAction( std::vector<GamepadAction> &actions, uint8_t event, const ActionMapping &mapping )
 {
   if ( mapping.empty() )

--- a/hector_gamepad_manager/src/gamepad_mapping_builder.cpp
+++ b/hector_gamepad_manager/src/gamepad_mapping_builder.cpp
@@ -27,9 +27,10 @@ std::string pluginId( const std::shared_ptr<GamepadFunctionPlugin> &plugin )
 }
 } // namespace
 
-hector_gamepad_manager_msgs::msg::GamepadMapping buildGamepadMappingMsg(
-    const std::map<std::string, GamepadConfig> &configs,
-    const std::array<ConfigSwitch, kNumButtons> &config_switches, const std::string &default_config )
+hector_gamepad_manager_msgs::msg::GamepadMapping
+buildGamepadMappingMsg( const std::map<std::string, GamepadConfig> &configs,
+                        const std::array<ConfigSwitch, kNumButtons> &config_switches,
+                        const std::string &default_config )
 {
   hector_gamepad_manager_msgs::msg::GamepadMapping msg;
   msg.default_config = default_config;

--- a/hector_gamepad_manager/src/hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/src/hector_gamepad_manager.cpp
@@ -1,5 +1,8 @@
 #include "hector_gamepad_manager/hector_gamepad_manager.hpp"
 
+#include "hector_gamepad_manager/gamepad_config.hpp"
+#include "hector_gamepad_manager/gamepad_mapping_builder.hpp"
+
 #include <filesystem>
 
 namespace hector_gamepad_manager
@@ -26,12 +29,18 @@ HectorGamepadManager::HectorGamepadManager( const rclcpp::Node::SharedPtr &node 
   qos_profile.durability( RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL );
   active_config_publisher_ =
       node_->create_publisher<std_msgs::msg::String>( "joy_teleop_profile", qos_profile );
+  mapping_publisher_ = node_->create_publisher<hector_gamepad_manager_msgs::msg::GamepadMapping>(
+      "joy_mapping", qos_profile );
   feedback_manager_->initialize( node_, "joy_feedback" );
   controller_orchestrator_ =
       std::make_shared<controller_orchestrator::ControllerOrchestrator>( node_ );
   // load meta switch config and all referenced config files
   if ( loadConfigSwitchesConfig( config_switches_filename ) ) {
     switchConfig( default_config_ );
+
+    // Configs are immutable after load, so the mapping is published once and latched.
+    mapping_publisher_->publish(
+        buildGamepadMappingMsg( configs_, config_switch_button_mapping_, default_config_ ) );
 
     joy_subscription_ = node_->create_subscription<sensor_msgs::msg::Joy>(
         "joy", 1, std::bind( &HectorGamepadManager::joyCallback, this, std::placeholders::_1 ) );
@@ -45,6 +54,11 @@ bool HectorGamepadManager::loadConfigSwitchesConfig( const std::string &file_nam
     const YAML::Node config = YAML::LoadFile( getPath( "hector_gamepad_manager", file_name ) );
     for ( const auto &entry : config["buttons"] ) {
       const int id = entry.first.as<int>();
+      if ( static_cast<size_t>( id ) >= kNumButtons ) {
+        RCLCPP_ERROR( node_->get_logger(), "Button ID %d exceeds maximum of %lu. Skipping.", id,
+                      kNumButtons - 1 );
+        continue;
+      }
       YAML::Node mapping = entry.second;
       auto config_name = mapping["config"].as<std::string>();
       auto pkg_name = mapping["package"].as<std::string>();
@@ -56,7 +70,10 @@ bool HectorGamepadManager::loadConfigSwitchesConfig( const std::string &file_nam
         RCLCPP_ERROR( node_->get_logger(), "Failed to load config file %s", config_name.c_str() );
         return false;
       }
-      config_switch_button_mapping_[id] = config_name;
+      std::string description;
+      if ( mapping["description"] )
+        description = mapping["description"].as<std::string>();
+      config_switch_button_mapping_[id] = { config_name, description };
     }
     default_config_ = config["default_config"].as<std::string>();
   } catch ( const std::exception &e ) {
@@ -73,6 +90,8 @@ bool HectorGamepadManager::loadConfig( const std::string &pkg_name, const std::s
 
     // Add empty mappings for the filename
     configs_[file_name] = GamepadConfig();
+    if ( config["description"] )
+      configs_[file_name].description = config["description"].as<std::string>();
 
     if ( !initButtonMappings( config, file_name, configs_[file_name].button_mappings ) ||
          !initMappings( config, "axes", file_name, configs_[file_name].axis_mappings ) ) {
@@ -125,6 +144,24 @@ bool HectorGamepadManager::ensurePluginLoaded( const std::string &plugin_name )
   }
 }
 
+namespace
+{
+// Read {function, description} from an event node (e.g. on_press). Empty mapping if absent.
+ActionMapping readAction( const YAML::Node &node, const std::string &description_fallback = "" )
+{
+  ActionMapping action;
+  if ( !node )
+    return action;
+  if ( node["function"] )
+    action.function = node["function"].as<std::string>();
+  if ( node["description"] )
+    action.description = node["description"].as<std::string>();
+  else
+    action.description = description_fallback;
+  return action;
+}
+} // namespace
+
 bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
                                                const std::string &config_name,
                                                std::unordered_map<int, ButtonFunctionMapping> &mappings )
@@ -147,19 +184,17 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
     // Detect new format: presence of on_press, on_double_press, on_hold, or on_release sub-keys
     const bool new_format = mapping["on_press"] || mapping["on_double_press"] ||
                             mapping["on_hold"] || mapping["on_release"];
+    const std::string &description =
+        mapping["description"] ? mapping["description"].as<std::string>() : "";
 
-    std::string on_press, on_double_press, on_hold, on_release;
+    ActionMapping on_press, on_double_press, on_hold, on_release;
     const std::string function_id = config_name + "_" + std::to_string( id );
 
     if ( new_format ) {
-      if ( mapping["on_press"] && mapping["on_press"]["function"] )
-        on_press = mapping["on_press"]["function"].as<std::string>();
-      if ( mapping["on_double_press"] && mapping["on_double_press"]["function"] )
-        on_double_press = mapping["on_double_press"]["function"].as<std::string>();
-      if ( mapping["on_hold"] && mapping["on_hold"]["function"] )
-        on_hold = mapping["on_hold"]["function"].as<std::string>();
-      if ( mapping["on_release"] && mapping["on_release"]["function"] )
-        on_release = mapping["on_release"]["function"].as<std::string>();
+      on_press = readAction( mapping["on_press"], description );
+      on_double_press = readAction( mapping["on_double_press"], description );
+      on_hold = readAction( mapping["on_hold"], description );
+      on_release = readAction( mapping["on_release"], description );
 
       // on_press is required as the timeout-flush dispatch target and on_hold/on_release fallback.
       if ( on_press.empty() ) {
@@ -197,7 +232,9 @@ bool HectorGamepadManager::initButtonMappings( const YAML::Node &config,
       auto function = mapping["function"].as<std::string>();
       if ( function.empty() )
         continue;
-      on_press = function;
+      on_press.function = function;
+      if ( mapping["description"] )
+        on_press.description = mapping["description"].as<std::string>();
       blackboard_->set_from_yaml( mapping["args"], plugin_name + "_" + function_id );
     }
 
@@ -221,6 +258,9 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
         continue;
       auto plugin_name = mapping["plugin"].as<std::string>();
       auto function = mapping["function"].as<std::string>();
+      std::string description;
+      if ( mapping["description"] )
+        description = mapping["description"].as<std::string>();
       const std::string function_id = config_name + "_" + std::to_string( id );
       if ( mapping["args"] ) {
         blackboard_->set_from_yaml( mapping["args"], plugin_name + std::string( "_" ) + function_id );
@@ -229,7 +269,7 @@ bool HectorGamepadManager::initMappings( const YAML::Node &config, const std::st
       if ( !plugin_name.empty() && !function.empty() ) {
         if ( !ensurePluginLoaded( plugin_name ) )
           return false;
-        mappings[id] = { plugins_[plugin_name], function };
+        mappings[id] = { plugins_[plugin_name], function, description };
       }
     }
   } else {
@@ -244,8 +284,8 @@ bool HectorGamepadManager::handleConfigurationSwitches( const GamepadInputs &inp
 
   // test if a button is pressed that is mapped to a config switch
   for ( size_t i = 0; i < config_switch_button_mapping_.size(); i++ ) {
-    if ( inputs.buttons[i] && !config_switch_button_mapping_[i].empty() ) {
-      switchConfig( config_switch_button_mapping_[i] );
+    if ( inputs.buttons[i] && !config_switch_button_mapping_[i].config.empty() ) {
+      switchConfig( config_switch_button_mapping_[i].config );
       return true;
     }
   }
@@ -270,7 +310,7 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
 
     if ( !mapping.has_double_press() ) {
       // No double-press configured → dispatch immediately via handleButton (original behavior)
-      const std::string &function = mapping.on_press;
+      const std::string &function = mapping.on_press.function;
       mapping.plugin->handleButton( function, id, pressed );
     } else {
       // Double-press enabled → buffered dispatch
@@ -286,13 +326,13 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
           // Second press within window → double press detected
           tracker.awaiting_double_press = false;
           tracker.press_dispatched = true;
-          mapping.plugin->handlePress( mapping.on_double_press, id );
+          mapping.plugin->handlePress( mapping.on_double_press.function, id );
         } else {
           // Flush a stale buffered tap before overwriting last_press_time, otherwise the original press is silently dropped when no callback fired during the wait window.
           if ( tracker.awaiting_double_press && window_expired ) {
-            mapping.plugin->handlePress( mapping.on_press, id );
+            mapping.plugin->handlePress( mapping.on_press.function, id );
             const std::string &release_fn =
-                mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+                mapping.on_release.empty() ? mapping.on_press.function : mapping.on_release.function;
             mapping.plugin->handleRelease( release_fn, id );
           }
           // First press → start waiting for potential second press
@@ -303,13 +343,14 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
       } else if ( pressed && was_pressed ) {
         // Held — only dispatch hold if press was already dispatched
         if ( tracker.press_dispatched ) {
-          const std::string &hold_fn = mapping.on_hold.empty() ? mapping.on_press : mapping.on_hold;
+          const std::string &hold_fn =
+              mapping.on_hold.empty() ? mapping.on_press.function : mapping.on_hold.function;
           mapping.plugin->handleHold( hold_fn, id );
         }
       } else if ( falling_edge ) {
         if ( tracker.press_dispatched ) {
           const std::string &release_fn =
-              mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+              mapping.on_release.empty() ? mapping.on_press.function : mapping.on_release.function;
           mapping.plugin->handleRelease( release_fn, id );
           tracker.press_dispatched = false;
         }
@@ -331,7 +372,7 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
     if ( tracker.awaiting_double_press && window_expired ) {
       tracker.awaiting_double_press = false;
       const std::string id = active_config_ + "_" + std::to_string( button_id );
-      mapping.plugin->handlePress( mapping.on_press, id );
+      mapping.plugin->handlePress( mapping.on_press.function, id );
 
       if ( tracker.pressed ) {
         // Still held — let subsequent frames drive hold/release through the normal path.
@@ -339,7 +380,7 @@ void HectorGamepadManager::joyCallback( const sensor_msgs::msg::Joy::SharedPtr m
       } else {
         // Quick tap: pair the delayed press with an immediate release so the plugin doesn't get stuck.
         const std::string &release_fn =
-            mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+            mapping.on_release.empty() ? mapping.on_press.function : mapping.on_release.function;
         mapping.plugin->handleRelease( release_fn, id );
         tracker.press_dispatched = false;
       }
@@ -417,14 +458,14 @@ void HectorGamepadManager::flushPendingButtonState()
 
     const std::string id = active_config_ + "_" + std::to_string( button_id );
     const std::string &release_fn =
-        mapping.on_release.empty() ? mapping.on_press : mapping.on_release;
+        mapping.on_release.empty() ? mapping.on_press.function : mapping.on_release.function;
 
     if ( tracker.press_dispatched ) {
       mapping.plugin->handleRelease( release_fn, id );
       tracker.press_dispatched = false;
     } else if ( tracker.awaiting_double_press ) {
       // Emit the same press+release pair the timeout-quick-tap path would have produced.
-      mapping.plugin->handlePress( mapping.on_press, id );
+      mapping.plugin->handlePress( mapping.on_press.function, id );
       mapping.plugin->handleRelease( release_fn, id );
     }
     tracker.awaiting_double_press = false;

--- a/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
+++ b/hector_gamepad_manager/test/config/manager_internal_malformed.yaml
@@ -29,7 +29,11 @@ buttons:
     plugin: hector_gamepad_manager_plugins::TestProbePlugin
     on_double_press: {function: probe_double}
   4: {plugin: '', function: ''}
-  5: {plugin: '', function: ''}
+  # Button RB: legacy entry with a description: but no function: — description must not make it
+  # valid; still skipped.
+  5:
+    plugin: hector_gamepad_manager_plugins::TestProbePlugin
+    description: Should be ignored
   6: {plugin: '', function: ''}
   7: {plugin: '', function: ''}
   8: {plugin: '', function: ''}

--- a/hector_gamepad_manager/test/test_gamepad_mapping_builder.cpp
+++ b/hector_gamepad_manager/test/test_gamepad_mapping_builder.cpp
@@ -15,12 +15,12 @@ class StubPlugin : public GamepadFunctionPlugin
 {
 public:
   explicit StubPlugin( const std::string &id ) { setPluginId( id ); }
-  void update() override {}
-  void activate() override {}
-  void deactivate() override {}
+  void update() override { }
+  void activate() override { }
+  void deactivate() override { }
 
 protected:
-  void initialize( const rclcpp::Node::SharedPtr & ) override {}
+  void initialize( const rclcpp::Node::SharedPtr & ) override { }
 };
 
 std::shared_ptr<GamepadFunctionPlugin> makePlugin( const std::string &id )
@@ -56,12 +56,12 @@ protected:
     // Legacy-flat button -> single on_press action.
     driving.button_mappings[0] = { drive, { "slow", "Drive slowly" }, {}, {}, {} };
     // Per-event button -> press + double-press actions.
-    driving.button_mappings[1] = { flipper,
-                                   { "individual_front_flipper_control_mode",
-                                     "Individual front flipper control" },
-                                   { "sync_front_flippers", "Sync front flippers" },
-                                   {},
-                                   {} };
+    driving.button_mappings[1] = {
+        flipper,
+        { "individual_front_flipper_control_mode", "Individual front flipper control" },
+        { "sync_front_flippers", "Sync front flippers" },
+        {},
+        {} };
     // Axis with a description, and an axis without one.
     driving.axis_mappings[0] = { drive, "steer", "Steer" };
     driving.axis_mappings[1] = { drive, "drive", "" };

--- a/hector_gamepad_manager/test/test_gamepad_mapping_builder.cpp
+++ b/hector_gamepad_manager/test/test_gamepad_mapping_builder.cpp
@@ -1,0 +1,156 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "hector_gamepad_manager/gamepad_mapping_builder.hpp"
+
+using namespace hector_gamepad_manager;
+using hector_gamepad_manager_msgs::msg::GamepadAction;
+
+namespace
+{
+// Minimal concrete plugin whose only job is to carry a plugin id for the builder to read.
+class StubPlugin : public GamepadFunctionPlugin
+{
+public:
+  explicit StubPlugin( const std::string &id ) { setPluginId( id ); }
+  void update() override {}
+  void activate() override {}
+  void deactivate() override {}
+
+protected:
+  void initialize( const rclcpp::Node::SharedPtr & ) override {}
+};
+
+std::shared_ptr<GamepadFunctionPlugin> makePlugin( const std::string &id )
+{
+  return std::make_shared<StubPlugin>( id );
+}
+
+// Find a button/axis entry by its index in an unsorted-by-value message array.
+template<typename Vec>
+const typename Vec::value_type *findByIndex( const Vec &vec, int index )
+{
+  for ( const auto &entry : vec )
+    if ( entry.index == index )
+      return &entry;
+  return nullptr;
+}
+} // namespace
+
+class GamepadMappingBuilderTest : public ::testing::Test
+{
+protected:
+  std::map<std::string, GamepadConfig> configs_;
+  std::array<ConfigSwitch, kNumButtons> switches_;
+  std::string default_config_ = "driving";
+
+  void SetUp() override
+  {
+    auto drive = makePlugin( "hector_gamepad_manager_plugins::DrivePlugin" );
+    auto flipper = makePlugin( "hector_gamepad_manager_plugins::FlipperPlugin" );
+
+    GamepadConfig driving;
+    driving.description = "Drive the robot and control the flippers";
+    // Legacy-flat button -> single on_press action.
+    driving.button_mappings[0] = { drive, { "slow", "Drive slowly" }, {}, {}, {} };
+    // Per-event button -> press + double-press actions.
+    driving.button_mappings[1] = { flipper,
+                                   { "individual_front_flipper_control_mode",
+                                     "Individual front flipper control" },
+                                   { "sync_front_flippers", "Sync front flippers" },
+                                   {},
+                                   {} };
+    // Axis with a description, and an axis without one.
+    driving.axis_mappings[0] = { drive, "steer", "Steer" };
+    driving.axis_mappings[1] = { drive, "drive", "" };
+    configs_["driving"] = driving;
+
+    switches_[6] = { "manipulation", "Switch to manipulation mode" };
+    switches_[7] = { "driving", "Switch to driving mode" };
+  }
+
+  hector_gamepad_manager_msgs::msg::GamepadMapping build()
+  {
+    return buildGamepadMappingMsg( configs_, switches_, default_config_ );
+  }
+};
+
+TEST_F( GamepadMappingBuilderTest, TopLevelFields )
+{
+  auto msg = build();
+  EXPECT_EQ( msg.default_config, "driving" );
+  ASSERT_EQ( msg.configs.size(), 1u );
+  EXPECT_EQ( msg.configs[0].name, "driving" );
+  EXPECT_EQ( msg.configs[0].description, "Drive the robot and control the flippers" );
+}
+
+TEST_F( GamepadMappingBuilderTest, LegacyFlatButtonYieldsSinglePressAction )
+{
+  auto msg = build();
+  const auto *button = findByIndex( msg.configs[0].buttons, 0 );
+  ASSERT_NE( button, nullptr );
+  EXPECT_EQ( button->plugin, "hector_gamepad_manager_plugins::DrivePlugin" );
+  ASSERT_EQ( button->actions.size(), 1u );
+  EXPECT_EQ( button->actions[0].event, GamepadAction::EVENT_PRESS );
+  EXPECT_EQ( button->actions[0].function, "slow" );
+  EXPECT_EQ( button->actions[0].description, "Drive slowly" );
+}
+
+TEST_F( GamepadMappingBuilderTest, PerEventButtonYieldsDistinctActions )
+{
+  auto msg = build();
+  const auto *button = findByIndex( msg.configs[0].buttons, 1 );
+  ASSERT_NE( button, nullptr );
+  ASSERT_EQ( button->actions.size(), 2u );
+  EXPECT_EQ( button->actions[0].event, GamepadAction::EVENT_PRESS );
+  EXPECT_EQ( button->actions[0].function, "individual_front_flipper_control_mode" );
+  EXPECT_EQ( button->actions[0].description, "Individual front flipper control" );
+  EXPECT_EQ( button->actions[1].event, GamepadAction::EVENT_DOUBLE_PRESS );
+  EXPECT_EQ( button->actions[1].function, "sync_front_flippers" );
+  EXPECT_EQ( button->actions[1].description, "Sync front flippers" );
+}
+
+TEST_F( GamepadMappingBuilderTest, ButtonsSortedByIndex )
+{
+  auto msg = build();
+  const auto &buttons = msg.configs[0].buttons;
+  ASSERT_EQ( buttons.size(), 2u );
+  EXPECT_EQ( buttons[0].index, 0 );
+  EXPECT_EQ( buttons[1].index, 1 );
+}
+
+TEST_F( GamepadMappingBuilderTest, AxesCarryDescriptionsAndEmptyStays )
+{
+  auto msg = build();
+  const auto &axes = msg.configs[0].axes;
+  ASSERT_EQ( axes.size(), 2u );
+  const auto *steer = findByIndex( axes, 0 );
+  ASSERT_NE( steer, nullptr );
+  EXPECT_EQ( steer->function, "steer" );
+  EXPECT_EQ( steer->description, "Steer" );
+  const auto *drive = findByIndex( axes, 1 );
+  ASSERT_NE( drive, nullptr );
+  EXPECT_EQ( drive->description, "" );
+}
+
+TEST_F( GamepadMappingBuilderTest, ConfigSwitchesPopulatedAndSorted )
+{
+  auto msg = build();
+  ASSERT_EQ( msg.config_switches.size(), 2u );
+  EXPECT_EQ( msg.config_switches[0].index, 6 );
+  EXPECT_EQ( msg.config_switches[0].config, "manipulation" );
+  EXPECT_EQ( msg.config_switches[0].description, "Switch to manipulation mode" );
+  EXPECT_EQ( msg.config_switches[1].index, 7 );
+  EXPECT_EQ( msg.config_switches[1].config, "driving" );
+}
+
+TEST_F( GamepadMappingBuilderTest, NullPluginYieldsEmptyName )
+{
+  configs_["driving"].button_mappings[3] = { nullptr, { "fast", "Drive fast" }, {}, {}, {} };
+  auto msg = build();
+  const auto *button = findByIndex( msg.configs[0].buttons, 3 );
+  ASSERT_NE( button, nullptr );
+  EXPECT_EQ( button->plugin, "" );
+}

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -18,6 +18,7 @@
 #include <std_msgs/msg/string.hpp>
 
 #include <hector_gamepad_manager/hector_gamepad_manager.hpp>
+#include <hector_gamepad_manager_msgs/msg/gamepad_mapping.hpp>
 
 #include <filesystem>
 #include <functional>
@@ -39,6 +40,8 @@ protected:
 
   std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Joy>> sub_joy_;
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_config_;
+  std::shared_ptr<rtest::PublisherMock<hector_gamepad_manager_msgs::msg::GamepadMapping>>
+      pub_mapping_;
   std::shared_ptr<rtest::PublisherMock<geometry_msgs::msg::TwistStamped>> pub_cmd_vel_;
   std::shared_ptr<rtest::PublisherMock<geometry_msgs::msg::TwistStamped>> pub_twist_eef_;
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::Float64>> pub_gripper_;
@@ -69,6 +72,8 @@ protected:
     sub_joy_ = rtest::findSubscription<sensor_msgs::msg::Joy>( node_, "/athena/joy" );
     pub_config_ =
         rtest::findPublisher<std_msgs::msg::String>( node_, "/athena/joy_teleop_profile" );
+    pub_mapping_ = rtest::findPublisher<hector_gamepad_manager_msgs::msg::GamepadMapping>(
+        node_, "/athena/joy_mapping" );
     pub_cmd_vel_ =
         rtest::findPublisher<geometry_msgs::msg::TwistStamped>( node_, "/athena/cmd_vel" );
     pub_twist_eef_ = rtest::findPublisher<geometry_msgs::msg::TwistStamped>(
@@ -84,6 +89,7 @@ protected:
 
     ASSERT_TRUE( sub_joy_ );
     ASSERT_TRUE( pub_config_ );
+    ASSERT_TRUE( pub_mapping_ );
     ASSERT_TRUE( pub_cmd_vel_ );
     ASSERT_TRUE( pub_twist_eef_ );
     ASSERT_TRUE( pub_gripper_ );

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager.cpp
@@ -40,8 +40,7 @@ protected:
 
   std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Joy>> sub_joy_;
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::String>> pub_config_;
-  std::shared_ptr<rtest::PublisherMock<hector_gamepad_manager_msgs::msg::GamepadMapping>>
-      pub_mapping_;
+  std::shared_ptr<rtest::PublisherMock<hector_gamepad_manager_msgs::msg::GamepadMapping>> pub_mapping_;
   std::shared_ptr<rtest::PublisherMock<geometry_msgs::msg::TwistStamped>> pub_cmd_vel_;
   std::shared_ptr<rtest::PublisherMock<geometry_msgs::msg::TwistStamped>> pub_twist_eef_;
   std::shared_ptr<rtest::PublisherMock<std_msgs::msg::Float64>> pub_gripper_;

--- a/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
+++ b/hector_gamepad_manager/test/test_hector_gamepad_manager_malformed.cpp
@@ -115,6 +115,12 @@ TEST_F( HectorGamepadManagerMalformedConfigTest, MalformedMappingsAreSkipped )
   sendJoy();
   setButton( 3, 0 );
   sendJoy();
+
+  // Button 5: legacy format with a description: but no function: — must be skipped.
+  setButton( 5, 1 );
+  sendJoy();
+  setButton( 5, 0 );
+  sendJoy();
 }
 
 // Test F — A valid entry coexisting with malformed entries in the same config still works.

--- a/hector_gamepad_manager_msgs/CMakeLists.txt
+++ b/hector_gamepad_manager_msgs/CMakeLists.txt
@@ -4,7 +4,8 @@ project(hector_gamepad_manager_msgs)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
+rosidl_generate_interfaces(
+  ${PROJECT_NAME}
   "msg/GamepadAction.msg"
   "msg/GamepadButtonMapping.msg"
   "msg/GamepadAxisMapping.msg"

--- a/hector_gamepad_manager_msgs/CMakeLists.txt
+++ b/hector_gamepad_manager_msgs/CMakeLists.txt
@@ -4,7 +4,14 @@ project(hector_gamepad_manager_msgs)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME} "srv/SetTargetRobot.srv")
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/GamepadAction.msg"
+  "msg/GamepadButtonMapping.msg"
+  "msg/GamepadAxisMapping.msg"
+  "msg/GamepadConfigSwitch.msg"
+  "msg/GamepadConfigMapping.msg"
+  "msg/GamepadMapping.msg"
+  "srv/SetTargetRobot.srv")
 
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/hector_gamepad_manager_msgs/msg/GamepadAction.msg
+++ b/hector_gamepad_manager_msgs/msg/GamepadAction.msg
@@ -1,0 +1,9 @@
+# One action bound to a button, for a single input event.
+uint8 EVENT_PRESS=0
+uint8 EVENT_DOUBLE_PRESS=1
+uint8 EVENT_HOLD=2
+uint8 EVENT_RELEASE=3
+
+uint8 event
+string function     # function name passed to the plugin
+string description  # human-readable, from YAML; may be empty

--- a/hector_gamepad_manager_msgs/msg/GamepadAxisMapping.msg
+++ b/hector_gamepad_manager_msgs/msg/GamepadAxisMapping.msg
@@ -1,0 +1,5 @@
+# Mapping of a single axis to a plugin function. Axes have no per-event format.
+uint8 index
+string plugin
+string function
+string description

--- a/hector_gamepad_manager_msgs/msg/GamepadButtonMapping.msg
+++ b/hector_gamepad_manager_msgs/msg/GamepadButtonMapping.msg
@@ -1,0 +1,5 @@
+# Mapping of a single button to its actions.
+# Buttons 0-10 are physical; 11-24 are virtual (axis deflection past a deadzone).
+uint8 index
+string plugin       # pluginlib class name, exactly as in YAML
+GamepadAction[] actions

--- a/hector_gamepad_manager_msgs/msg/GamepadConfigMapping.msg
+++ b/hector_gamepad_manager_msgs/msg/GamepadConfigMapping.msg
@@ -1,0 +1,5 @@
+# Full button/axis mapping of a single configuration.
+string name         # config/file name, e.g. "driving" - matches joy_teleop_profile
+string description  # optional top-level description from the mapping YAML
+GamepadButtonMapping[] buttons
+GamepadAxisMapping[] axes

--- a/hector_gamepad_manager_msgs/msg/GamepadConfigSwitch.msg
+++ b/hector_gamepad_manager_msgs/msg/GamepadConfigSwitch.msg
@@ -1,0 +1,4 @@
+# A globally reserved button that switches the active configuration.
+uint8 index
+string config       # config this button switches to
+string description

--- a/hector_gamepad_manager_msgs/msg/GamepadMapping.msg
+++ b/hector_gamepad_manager_msgs/msg/GamepadMapping.msg
@@ -1,0 +1,4 @@
+# Full static gamepad mapping. Latched; published once at startup.
+string default_config                  # config active at startup
+GamepadConfigMapping[] configs
+GamepadConfigSwitch[] config_switches  # globally reserved config-switch buttons


### PR DESCRIPTION
This adds a description field for each button function for a human readable description of the mapped action.
The parsed config is then advertised on joy_mapping and used by the UI to display the gamepad configuration:

<img width="1309" height="880" alt="Screenshot from 2026-07-17 09-19-07" src="https://github.com/user-attachments/assets/3e786823-3d31-4dfa-9a71-3105f02fb72c" />
